### PR TITLE
Fix #10 empty body as object

### DIFF
--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -522,9 +522,8 @@ class Kuzzle
 
         foreach ($query as $attr => $value) {
             if ($attr === 'body' && empty($value)) {
-              $request['body'] = (object)[];
-            }
-            else if ($attr !== 'metadata') {
+                $request['body'] = (object)[];
+            } else if ($attr !== 'metadata') {
                 $request[$attr] = $value;
             }
         }

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -521,7 +521,10 @@ class Kuzzle
         }
 
         foreach ($query as $attr => $value) {
-            if ($attr !== 'metadata') {
+            if ($attr === 'body' && empty($value)) {
+              $request['body'] = (object)[];
+            }
+            else if ($attr !== 'metadata') {
                 $request[$attr] = $value;
             }
         }

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -388,7 +388,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                 'requestId' => $requestId,
                 'collection' => $collection,
                 'index' => $index,
-                'body' => $filters
+                'body' => (object)$filters
             ]
         ];
 

--- a/tests/KuzzleTest.php
+++ b/tests/KuzzleTest.php
@@ -1697,6 +1697,59 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testQueryWithEmptyBody()
+    {
+        $url = self::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+
+        $queryArgs = [
+            'route' => '/api/1.0/my-foo',
+            'method' => 'POST',
+        ];
+        $query = [
+          'body' => []
+        ];
+        $options = [
+            'metadata' => [],
+            'requestId' => $requestId
+        ];
+
+        $httpRequest = [
+            'route' => '/api/1.0/my-foo',
+            'method' => 'POST',
+            'request' => [
+              'body' => (object)[],
+              'metadata' => [],
+              'controller' => '',
+              'action' => '',
+              'requestId' => $requestId
+            ]
+        ];
+        $httpResponse = [];
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        /**
+         * @var \Kuzzle\Kuzzle $kuzzle
+         */
+        try {
+            $result = $kuzzle->query($queryArgs, $query, $options);
+        }
+        catch (Exception $e) {
+            $this->fail('KuzzleTest::testQuery => Should not raise an exception');
+        }
+    }
+
     public function testAddListener()
     {
         $url = self::FAKE_KUZZLE_HOST;


### PR DESCRIPTION
When we request Kuzzle with an empty body (for example for `fetchAllDocuments`, or `advancedSearch` with empty filters), it is converted into an empty JSON **array** (`[]`), while Kuzzle wants a JSON **object** (`{}`).

This PR fixes that, forcing to create an empty std object when the body is empty.
