### PR TITLE
KUZ-663: KuzzleDataCollection constructor signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+*__note:__ the # at the end of lines are the pull request numbers on GitHub*
+
+# Current
+
+## Breaking Changes
+
+* `KuzzleDataCollection` constructor signature has been changed from:  
+`KuzzleDataCollection(kuzzle, index, collection)`  
+ to:  
+`KuzzleDataCollection(kuzzle, collection, index)`  
+This has been done to make it on par with the `Kuzzle.dataCollectionFactory` method

--- a/src/DataCollection.php
+++ b/src/DataCollection.php
@@ -34,10 +34,10 @@ class DataCollection
      * DataCollection constructor.
      *
      * @param Kuzzle $kuzzle Kuzzle object
-     * @param string $index Name of the index containing the data collection
      * @param string $collection The name of the data collection you want to manipulate
+     * @param string $index Name of the index containing the data collection
      */
-    public function __construct(Kuzzle $kuzzle, $index, $collection)
+    public function __construct(Kuzzle $kuzzle, $collection, $index)
     {
         $this->kuzzle = $kuzzle;
         $this->index = $index;
@@ -368,7 +368,7 @@ class DataCollection
             '_id' => $documentId,
             'body' => $content
         ];
-        
+
         $queryArgs = $this->buildQueryArgs('write', 'update');
         $queryArgs['route'] = '/api/1.0/' . $this->index . '/' . $this->collection . '/' . $documentId . '/_update';
         $queryArgs['method'] = 'put';

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -189,7 +189,7 @@ class Kuzzle
         }
 
         if (!array_key_exists($collection, $this->collections[$index])) {
-            $this->collections[$index][$collection] = new DataCollection($this, $index, $collection);
+            $this->collections[$index][$collection] = new DataCollection($this, $collection, $index);
         }
 
         return $this->collections[$index][$collection];

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -70,7 +70,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $searchResult = $dataCollection->advancedSearch($filter, ['requestId' => $requestId]);
 
@@ -135,7 +135,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $count = $dataCollection->count($filter, ['requestId' => $requestId]);
 
@@ -184,7 +184,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $result = $dataCollection->create(['requestId' => $requestId]);
 
@@ -242,7 +242,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $document = $dataCollection->createDocument($documentContent, $documentId, ['requestId' => $requestId]);
 
@@ -303,7 +303,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $documentObject = new \Kuzzle\Document($dataCollection, $documentId, $documentContent);
 
@@ -361,7 +361,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $result = $dataCollection->deleteDocument($documentId, ['requestId' => $requestId]);
 
@@ -415,7 +415,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $result = $dataCollection->deleteDocument($filters, ['requestId' => $requestId]);
 
@@ -472,7 +472,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $document = $dataCollection->fetchDocument($documentId, ['requestId' => $requestId]);
 
@@ -543,7 +543,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $searchResult = $dataCollection->fetchAllDocuments(['from' => 0, 'size' => 10, 'requestId' => $requestId]);
 
@@ -603,7 +603,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $result = $dataCollection->publishMessage($document, ['requestId' => $requestId]);
 
@@ -659,7 +659,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $documentObject = new \Kuzzle\Document($dataCollection, $documentId, $document);
 
@@ -719,7 +719,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $document = $dataCollection->replaceDocument($documentId, $documentContent, ['requestId' => $requestId]);
 
@@ -773,7 +773,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $result = $dataCollection->truncate(['requestId' => $requestId]);
 
@@ -860,7 +860,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
         $document = $dataCollection->updateDocument($documentId, $documentContent, ['requestId' => $requestId]);
 

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -55,7 +55,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
         $document = new Document($dataCollection, $documentId, $documentContent);
 
         $result = $document->delete(['requestId' => $requestId]);
@@ -71,7 +71,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $collection = 'collection';
 
         $kuzzle = new \Kuzzle\Kuzzle($url);
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
         $document = new Document($dataCollection);
 
         try {
@@ -93,7 +93,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $collection = 'collection';
 
         $kuzzle = new \Kuzzle\Kuzzle($url);
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
         $document = new Document($dataCollection);
 
         try {
@@ -158,7 +158,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
         $document = new Document($dataCollection, $documentId, $documentContent);
 
         $document->setContent(['baz' => 'baz']);
@@ -219,7 +219,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         /**
          * @var Kuzzle $kuzzle
          */
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
         $document = new Document($dataCollection, $documentId, $documentContent);
 
         $document->setContent(['baz' => 'baz']);
@@ -242,7 +242,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         ];
 
         $kuzzle = new \Kuzzle\Kuzzle($url);
-        $dataCollection = new DataCollection($kuzzle, $index, $collection);
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
         $document = $dataCollection->documentFactory($documentId, array_merge($documentContent, ['_version' => 1]));
 
         $result = $document->serialize();


### PR DESCRIPTION
For the sake of consistency, the KuzzleDataCollection constructor has been changed so that its signature matches `Kuzzle.dataCollectionFactory`
