### PR TITLE
Kuz 24 implement scroll api

### DIFF
--- a/examples/document.php
+++ b/examples/document.php
@@ -12,44 +12,85 @@ $collection = $kuzzle->dataCollectionFactory('mycollection', 'myindex');
 // delete documents in collection
 try {
     $deleteResult = $collection->deleteDocument([]);
-    var_dump($deleteResult);
+    print_r('delete documents in collection');
+    print_r("\n");
+    print_r($deleteResult);
 }
 catch (ErrorException $e) {
+    $kuzzle->createIndex('myindex');
     $collection->create();
 }
 
 
 // add a document
+print_r('add a document');
+print_r("\n");
 $document = $collection->createDocument(['foo' => 'bar']);
-var_dump($document->serialize());
+print_r($document->serialize());
 
 // add another document
+print_r('add another document');
+print_r("\n");
 $document = $collection->createDocument(['foo' => 'baz']);
-var_dump($document->serialize());
+print_r($document->serialize());
+
+// add a third document
+print_r('add a third document');
+print_r("\n");
+$document = $collection->createDocument(['foo' => 'qux']);
+print_r($document->serialize());
 
 // get document
+print_r('get document');
+print_r("\n");
 $document = $collection->fetchDocument($document->getId());
-var_dump($document->serialize());
+print_r($document->serialize());
+
+// search with scroll results
+print_r('search with scroll results:');
+print_r("\n");
 
 $filter = [
+    'scroll' => '1m',
+    'from' => 0,
+    'size' => 1,
     'query' => [
         'bool' => [
             'should' => [
-                'term' => ['foo' => 'bar']
+                'exists' => ['field' => 'foo']
             ]
         ]
     ]
 ];
+$searchResult = $collection->search($filter);
 
-sleep(1);
+while ($searchResult) {
+    foreach ($searchResult->getDocuments() as $document) {
+        print_r($document->serialize());
+    }
+    $searchResult = $searchResult->getNext();
+}
 
-// search all documents
-$searchResult = $collection->advancedSearch($filter);
+// search without scroll results
+print_r('search without scroll results:');
+print_r("\n");
 
-// count without fetch
-$searchCount = $collection->count($filter);
-var_dump('documents found:', $searchResult->getTotal(), $searchCount);
+$filter = [
+    'from' => 0,
+    'size' => 1,
+    'query' => [
+        'bool' => [
+            'should' => [
+                'exists' => ['field' => 'foo']
+            ]
+        ]
+    ]
+];
+$searchResult = $collection->search($filter);
 
-foreach ($searchResult->getDocuments() as $document) {
-    var_dump($document->serialize());
+while ($searchResult) {
+    foreach ($searchResult->getDocuments() as $document) {
+        print_r($document->serialize());
+    }
+    $searchResult = $searchResult->getNext();
 }

--- a/examples/document.php
+++ b/examples/document.php
@@ -46,6 +46,9 @@ print_r("\n");
 $document = $collection->fetchDocument($document->getId());
 print_r($document->serialize());
 
+// wait for indexing
+sleep(2);
+
 // search with scroll results
 print_r('search with scroll results:');
 print_r("\n");
@@ -63,13 +66,16 @@ $filter = [
     ]
 ];
 $searchResult = $collection->search($filter);
+$nbDocs = 0;
 
 while ($searchResult) {
     foreach ($searchResult->getDocuments() as $document) {
         print_r($document->serialize());
+        $nbDocs++;
     }
     $searchResult = $searchResult->getNext();
 }
+print_r('search with scroll results total:' . $nbDocs . "\n");
 
 // search without scroll results
 print_r('search without scroll results:');
@@ -87,10 +93,13 @@ $filter = [
     ]
 ];
 $searchResult = $collection->search($filter);
+$nbDocs = 0;
 
 while ($searchResult) {
     foreach ($searchResult->getDocuments() as $document) {
         print_r($document->serialize());
+        $nbDocs++;
     }
     $searchResult = $searchResult->getNext();
 }
+print_r('search without scroll results total:' . $nbDocs . "\n");

--- a/src/DataCollection.php
+++ b/src/DataCollection.php
@@ -2,7 +2,7 @@
 
 namespace Kuzzle;
 
-use Kuzzle\Util\AdvancedSearchResult;
+use Kuzzle\Util\SearchResult;
 
 /**
  * Class DataCollection
@@ -54,7 +54,7 @@ class DataCollection
      *
      * @param array $filters Filters in ElasticSearch Query DSL format
      * @param array $options Optional parameters
-     * @return AdvancedSearchResult
+     * @return SearchResult
      */
     public function advancedSearch(array $filters, array $options = [])
     {
@@ -68,7 +68,7 @@ class DataCollection
      *
      * @param array $filters Filters in ElasticSearch Query DSL format
      * @param array $options Optional parameters
-     * @return AdvancedSearchResult
+     * @return SearchResult
      */
     public function search(array $filters, array $options = [])
     {
@@ -91,7 +91,7 @@ class DataCollection
             $options['scrollId'] = $response['result']['_scroll_id'];
         }
 
-        return new AdvancedSearchResult($this, $response['result']['total'], $response['result']['hits'], ['filters' => $filters, 'options' => $options]);
+        return new SearchResult($this, $response['result']['total'], $response['result']['hits'], ['filters' => $filters, 'options' => $options]);
     }
 
     /**

--- a/src/DataCollection.php
+++ b/src/DataCollection.php
@@ -58,6 +58,8 @@ class DataCollection
      */
     public function advancedSearch(array $filters, array $options = [])
     {
+        trigger_error('Usage of Kuzzle\\DataCollection::advancedSearch is deprecated. Use Kuzzle\\DataCollection::search instead', E_USER_WARNING);
+
         return $this->search($filters, $options);
     }
 

--- a/src/DataCollection.php
+++ b/src/DataCollection.php
@@ -264,16 +264,19 @@ class DataCollection
 
         if (array_key_exists('scroll', $options)) {
             $filters['scroll'] = $options['scroll'];
+            unset($options['scroll']);
         }
 
         if (array_key_exists('from', $options)) {
             $filters['from'] = $options['from'];
+            unset($options['from']);
         } else {
             $filters['from'] = 0;
         }
 
         if (array_key_exists('size', $options)) {
             $filters['size'] = $options['size'];
+            unset($options['size']);
         } else {
             $filters['size'] = 1000;
         }

--- a/src/DataCollection.php
+++ b/src/DataCollection.php
@@ -49,11 +49,26 @@ class DataCollection
     /**
      * Executes an advanced search on the data collection.
      *
+     * @deprecated
+     * @see search
+     *
      * @param array $filters Filters in ElasticSearch Query DSL format
      * @param array $options Optional parameters
      * @return AdvancedSearchResult
      */
     public function advancedSearch(array $filters, array $options = [])
+    {
+        return $this->search($filters, $options);
+    }
+
+    /**
+     * Executes an advanced search on the data collection.
+     *
+     * @param array $filters Filters in ElasticSearch Query DSL format
+     * @param array $options Optional parameters
+     * @return AdvancedSearchResult
+     */
+    public function search(array $filters, array $options = [])
     {
         $data = [
             'body' => $filters
@@ -69,7 +84,12 @@ class DataCollection
             return new Document($this, $document['_id'], $document['_source']);
         }, $response['result']['hits']);
 
-        return new AdvancedSearchResult($response['result']['total'], $response['result']['hits']);
+
+        if (array_key_exists('_scroll_id', $response['result'])) {
+            $options['scrollId'] = $response['result']['_scroll_id'];
+        }
+
+        return new AdvancedSearchResult($this, $response['result']['total'], $response['result']['hits'], ['filters' => $filters, 'options' => $options]);
     }
 
     /**

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -172,7 +172,8 @@ class Kuzzle
      * @param array $options
      * @return mixed
      */
-    public function createIndex($index, array $options = []) {
+    public function createIndex($index, array $options = [])
+    {
         $options['httpParams'] = [
             ':index' => $index
         ];
@@ -795,9 +796,7 @@ class Kuzzle
 
         return $this->query(
             $this->buildQueryArgs('read', 'scroll'),
-            [
-                'body' => ['scrollId' => $scrollId]
-            ],
+            [],
             $options
         );
     }

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -790,13 +790,22 @@ class Kuzzle
      * @param array $options (optional) arguments
      * @return array raw kuzzle response
      */
+
     public function scroll($scrollId, array $options = [])
     {
         $options['httpParams'] = [':scrollId' => $scrollId];
 
+        $data = [
+            'body' => []
+        ];
+
+        if (array_key_exists('scroll', $options)) {
+            $data['body']['scroll'] = $options['scroll'];
+        }
+
         return $this->query(
             $this->buildQueryArgs('read', 'scroll'),
-            [],
+            $data,
             $options
         );
     }

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -166,6 +166,29 @@ class Kuzzle
     }
 
     /**
+     * Create an index
+     *
+     * @param $index
+     * @param array $options
+     * @return mixed
+     */
+    public function createIndex($index, array $options = []) {
+        $options['httpParams'] = [
+            ':index' => $index
+        ];
+
+        $response = $this->query(
+            $this->buildQueryArgs('admin', 'createIndex'),
+            [
+                'body' => ['index' => $index]
+            ],
+            $options
+        );
+
+        return $response['result'];
+    }
+
+    /**
      * Instantiates a new KuzzleDataCollection object.
      *
      * @param string $collection The name of the data collection you want to manipulate
@@ -757,6 +780,26 @@ class Kuzzle
         $this->jwtToken = $jwtToken;
 
         return $this;
+    }
+
+    /**
+     * Retrieves next result of a search with scroll query.
+     *
+     * @param string $scrollId
+     * @param array $options (optional) arguments
+     * @return array raw kuzzle response
+     */
+    public function scroll($scrollId, array $options = [])
+    {
+        $options['httpParams'] = [':scrollId' => $scrollId];
+
+        return $this->query(
+            $this->buildQueryArgs('read', 'scroll'),
+            [
+                'body' => ['scrollId' => $scrollId]
+            ],
+            $options
+        );
     }
 
     /**

--- a/src/Util/AdvancedSearchResult.php
+++ b/src/Util/AdvancedSearchResult.php
@@ -2,10 +2,17 @@
 
 namespace Kuzzle\Util;
 
+use InvalidArgumentException;
+use Kuzzle\DataCollection;
 use Kuzzle\Document;
 
 class AdvancedSearchResult
 {
+    /**
+     * @var DataCollection
+     */
+    private $dataCollection = null;
+
     /**
      * @var integer
      */
@@ -17,15 +24,31 @@ class AdvancedSearchResult
     private $documents = [];
 
     /**
+     * @var array
+     */
+    private $searchArgs = [];
+
+    /**
+     * @var AdvancedSearchResult
+     */
+    private $previous = null;
+
+    /**
      * AdvancedSearchResult constructor.
      *
+     * @param DataCollection $dataCollection
      * @param integer $total
      * @param Document[] $documents
+     * @param array $searchArgs
+     * @param AdvancedSearchResult $previous
      */
-    public function __construct($total, array $documents)
+    public function __construct(DataCollection $dataCollection, $total, array $documents, array $searchArgs = [], AdvancedSearchResult $previous = null)
     {
+        $this->dataCollection = $dataCollection;
         $this->total = $total;
         $this->documents = $documents;
+        $this->searchArgs = $searchArgs;
+        $this->previous = $previous;
 
         return $this;
     }
@@ -44,5 +67,67 @@ class AdvancedSearchResult
     public function getDocuments()
     {
         return $this->documents;
+    }
+
+    /**
+     * @return AdvancedSearchResult
+     */
+    public function getNext()
+    {
+        if (array_key_exists('scrollId', $this->searchArgs['options'])) {
+            $response = $this->dataCollection->getKuzzle()->scroll(
+                $this->searchArgs['options']['scrollId'],
+                $this->searchArgs['options']
+            );
+
+            $fetchedDocuments = count($this->documents);
+            $previous = $this;
+
+            while ($previous = $previous->getPrevious()) {
+                $fetchedDocuments += count($previous->getDocuments());
+            }
+
+            if ($fetchedDocuments >= $this->getTotal()) {
+                return null;
+            }
+
+            $response['result']['hits'] = array_map(function ($document) {
+                return new Document($this->dataCollection, $document['_id'], $document['_source']);
+            }, $response['result']['hits']);
+
+            return new AdvancedSearchResult($this->dataCollection, $response['result']['total'], $response['result']['hits'], $this->searchArgs, $this);
+        } else if (array_key_exists('from', $this->searchArgs['filters']) && array_key_exists('size', $this->searchArgs['filters'])) {
+            $filters = $this->searchArgs['filters'];
+            $filters['from'] += $filters['size'];
+
+            if ($filters['from'] >= $this->getTotal()) {
+                return null;
+            }
+
+            $searchResult = $this->dataCollection->search($filters, $this->searchArgs['options']);
+            $searchResult->setPrevious($this);
+
+            return $searchResult;
+        }
+
+        throw new InvalidArgumentException('Unable to retrieve next results from search: missing scrollId or from/size params');
+    }
+
+    /**
+     * @return AdvancedSearchResult
+     */
+    public function getPrevious() {
+        return $this->previous;
+    }
+
+    /**
+     * @param AdvancedSearchResult $previous
+     *
+     * @return $this
+     */
+    public function setPrevious(AdvancedSearchResult $previous) {
+        $this->previous = $previous;
+
+        return $this;
     }
 }

--- a/src/Util/AdvancedSearchResult.php
+++ b/src/Util/AdvancedSearchResult.php
@@ -116,7 +116,8 @@ class AdvancedSearchResult
     /**
      * @return AdvancedSearchResult
      */
-    public function getPrevious() {
+    public function getPrevious()
+    {
         return $this->previous;
     }
 
@@ -125,7 +126,8 @@ class AdvancedSearchResult
      *
      * @return $this
      */
-    public function setPrevious(AdvancedSearchResult $previous) {
+    public function setPrevious(AdvancedSearchResult $previous)
+    {
         $this->previous = $previous;
 
         return $this;

--- a/src/Util/SearchResult.php
+++ b/src/Util/SearchResult.php
@@ -68,6 +68,10 @@ class SearchResult
         $this->searchArgs = $searchArgs;
         $this->previous = $previous;
 
+        if ($this->previous instanceof SearchResult) {
+            $this->previous->setNext($this);
+        }
+
         return $this;
     }
 

--- a/src/config/routes.json
+++ b/src/config/routes.json
@@ -1490,6 +1490,11 @@
       "name": "search",
       "route": "/api/1.0/:index/:collection/_search"
     },
+    "scroll": {
+      "method": "get",
+      "name": "scroll",
+      "route": "/api/1.0/_scroll/:scrollId"
+    },
     "serverInfo": {
       "name": "serverInfo"
     }

--- a/src/config/routes.json
+++ b/src/config/routes.json
@@ -1491,7 +1491,7 @@
       "route": "/api/1.0/:index/:collection/_search"
     },
     "scroll": {
-      "method": "get",
+      "method": "post",
       "name": "scroll",
       "route": "/api/1.0/_scroll/:scrollId"
     },

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -74,7 +74,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
 
         $searchResult = $dataCollection->search($filter, ['requestId' => $requestId]);
 
-        $this->assertInstanceOf('Kuzzle\Util\AdvancedSearchResult', $searchResult);
+        $this->assertInstanceOf('Kuzzle\Util\SearchResult', $searchResult);
         $this->assertEquals(2, $searchResult->getTotal());
 
         $documents = $searchResult->getDocuments();

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -511,11 +511,12 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
 
         $httpScrollRequest = [
             'route' => '/api/1.0/_scroll/' . $scrollId,
-            'method' => 'GET',
+            'method' => 'POST',
             'request' => [
                 'metadata' => [],
                 'controller' => 'read',
                 'action' => 'scroll',
+                'body' => ['scroll' => '30s'],
                 'requestId' => $requestId,
             ]
         ];

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -4,7 +4,7 @@ use Kuzzle\Kuzzle;
 
 class DataCollectionTest extends \PHPUnit_Framework_TestCase
 {
-    function testAdvancedSearch()
+    function testSearch()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;
         $requestId = uniqid();
@@ -72,7 +72,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
-        $searchResult = $dataCollection->advancedSearch($filter, ['requestId' => $requestId]);
+        $searchResult = $dataCollection->search($filter, ['requestId' => $requestId]);
 
         $this->assertInstanceOf('Kuzzle\Util\AdvancedSearchResult', $searchResult);
         $this->assertEquals(2, $searchResult->getTotal());
@@ -482,18 +482,20 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals(1, 'version', $document);
     }
 
-    function testFetchAllDocuments()
+    function testFetchAllDocumentsWithScroll()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;
         $requestId = uniqid();
+        $scrollId = uniqid();
         $index = 'index';
         $collection = 'collection';
         $filter = [
             'from' => 0,
-            'size' => 10
+            'size' => 1,
+            'scroll' => '30s'
         ];
 
-        $httpRequest = [
+        $httpSearchRequest = [
             'route' => '/api/1.0/' . $index . '/' . $collection . '/_search',
             'method' => 'POST',
             'request' => [
@@ -506,15 +508,32 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                 'index' => $index
             ]
         ];
-        $advancedSearchResponse = [
+
+        $httpScrollRequest = [
+            'route' => '/api/1.0/_scroll/' . $scrollId,
+            'method' => 'GET',
+            'request' => [
+                'metadata' => [],
+                'controller' => 'read',
+                'action' => 'scroll',
+                'requestId' => $requestId,
+            ]
+        ];
+        $searchResponse = [
             'hits' => [
                 0 => [
                     '_id' => 'test',
                     '_source' => [
                         'foo' => 'bar'
                     ]
-                ],
-                1 => [
+                ]
+            ],
+            '_scroll_id' => $scrollId,
+            'total' => 2
+        ];
+        $scrollResponse = [
+            'hits' => [
+                0 => [
                     '_id' => 'test1',
                     '_source' => [
                         'foo' => 'bar'
@@ -523,9 +542,13 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
             ],
             'total' => 2
         ];
-        $httpResponse = [
+        $httpSearchResponse = [
             'error' => null,
-            'result' => $advancedSearchResponse
+            'result' => $searchResponse
+        ];
+        $httpScrollResponse = [
+            'error' => null,
+            'result' => $scrollResponse
         ];
 
         $kuzzle = $this
@@ -535,22 +558,135 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $kuzzle
-            ->expects($this->once())
+            ->expects($this->at(0))
             ->method('emitRestRequest')
-            ->with($httpRequest)
-            ->willReturn($httpResponse);
+            ->with($httpSearchRequest)
+            ->willReturn($httpSearchResponse);
+
+        $kuzzle
+            ->expects($this->at(1))
+            ->method('emitRestRequest')
+            ->with($httpScrollRequest)
+            ->willReturn($httpScrollResponse);
 
         /**
          * @var Kuzzle $kuzzle
          */
         $dataCollection = new DataCollection($kuzzle, $collection, $index);
 
-        $searchResult = $dataCollection->fetchAllDocuments(['from' => 0, 'size' => 10, 'requestId' => $requestId]);
+        $documents = $dataCollection->fetchAllDocuments(['from' => 0, 'size' => 1, 'scroll' => '30s', 'requestId' => $requestId]);
 
-        $this->assertInstanceOf('Kuzzle\Util\AdvancedSearchResult', $searchResult);
-        $this->assertEquals(2, $searchResult->getTotal());
+        $this->assertInternalType('array', $documents);
+        $this->assertEquals(2, count($documents));
 
-        $documents = $searchResult->getDocuments();
+        $this->assertInstanceOf('Kuzzle\Document', $documents[0]);
+        $this->assertAttributeEquals('test', 'id', $documents[0]);
+        $this->assertAttributeEquals('test1', 'id', $documents[1]);
+    }
+
+    function testFetchAllDocumentsWithoutScroll()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $scrollId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $filter = [
+            'from' => 0,
+            'size' => 1
+        ];
+        $secondFilter = [
+            'from' => 1,
+            'size' => 1
+        ];
+
+        $httpSearchRequest = [
+            'route' => '/api/1.0/' . $index . '/' . $collection . '/_search',
+            'method' => 'POST',
+            'request' => [
+                'metadata' => [],
+                'controller' => 'read',
+                'action' => 'search',
+                'requestId' => $requestId,
+                'body' => $filter,
+                'collection' => $collection,
+                'index' => $index
+            ]
+        ];
+
+        $httpSecondSearchRequest = [
+            'route' => '/api/1.0/' . $index . '/' . $collection . '/_search',
+            'method' => 'POST',
+            'request' => [
+                'metadata' => [],
+                'controller' => 'read',
+                'action' => 'search',
+                'requestId' => $requestId,
+                'body' => $secondFilter,
+                'collection' => $collection,
+                'index' => $index
+            ]
+        ];
+        $searchResponse = [
+            'hits' => [
+                0 => [
+                    '_id' => 'test',
+                    '_source' => [
+                        'foo' => 'bar'
+                    ]
+                ]
+            ],
+            'total' => 2
+        ];
+        $httpSecondSearchResponse = [
+            'hits' => [
+                0 => [
+                    '_id' => 'test1',
+                    '_source' => [
+                        'foo' => 'bar'
+                    ]
+                ]
+            ],
+            'total' => 2
+        ];
+        $httpSearchResponse = [
+            'error' => null,
+            'result' => $searchResponse
+        ];
+        $httpSecondSearchResponse = [
+            'error' => null,
+            'result' => $httpSecondSearchResponse
+        ];
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $kuzzle
+            ->expects($this->at(0))
+            ->method('emitRestRequest')
+            ->with($httpSearchRequest)
+            ->willReturn($httpSearchResponse);
+
+        $kuzzle
+            ->expects($this->at(1))
+            ->method('emitRestRequest')
+            ->with($httpSecondSearchRequest)
+            ->willReturn($httpSecondSearchResponse);
+
+        /**
+         * @var Kuzzle $kuzzle
+         */
+        $dataCollection = new DataCollection($kuzzle, $collection, $index);
+
+        $documents = $dataCollection->fetchAllDocuments(['from' => 0, 'size' => 1, 'requestId' => $requestId]);
+
+        $this->assertInternalType('array', $documents);
+        $this->assertEquals(2, count($documents));
+
         $this->assertInstanceOf('Kuzzle\Document', $documents[0]);
         $this->assertAttributeEquals('test', 'id', $documents[0]);
         $this->assertAttributeEquals('test1', 'id', $documents[1]);

--- a/tests/KuzzleTest.php
+++ b/tests/KuzzleTest.php
@@ -314,7 +314,8 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $options = [
-            'requestId' => uniqid()
+            'requestId' => uniqid(),
+            'scroll' => '1m'
         ];
 
         // mock http request
@@ -324,9 +325,10 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
                 'action' => 'scroll',
                 'controller' => 'read',
                 'metadata' => [],
+                'body' => ['scroll' => '1m'],
                 'requestId' => $options['requestId']
             ],
-            'method' => 'GET'
+            'method' => 'POST'
         ];
 
         // mock response


### PR DESCRIPTION
fixes #24 & #22 

* Migrate `advancedSearch` method to `search`
* Renamed `AdvancedSearchResult` class to `SearchResult`
* Implement `scroll` (see kuzzleio/kuzzle#516)
* Implement `createIndex`
* Update samples in `examples/document.php`