### PR TITLE
Add createRestrictedUser in security

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzleio/kuzzle-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Official PHP SDK for Kuzzle",
   "homepage": "http://kuzzle.io",
   "license": "Apache-2.0",

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -136,6 +136,31 @@ class Security
     }
 
     /**
+     * Create a new restricted user in Kuzzle.
+     *
+     * @param integer $id Unique user identifier, will be used as username
+     * @param array $content Data representing the user
+     * @param array $options Optional arguments
+     * @return User
+     */
+    public function createRestrictedUser($id, array $content, array $options = [])
+    {
+        $action = 'createRestrictedUser';
+        $data = [
+            '_id' => $id,
+            'body' => $content
+        ];
+
+        $response = $this->kuzzle->query(
+            $this->buildQueryArgs($action),
+            $data,
+            $options
+        );
+
+        return new User($this, $response['result']['_id'], $response['result']['_source']);
+    }
+
+    /**
      * Delete profile.
      *
      * @param integer $id Unique profile identifier to delete

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -42,7 +42,7 @@ class User extends Document
     {
         $profiles = [];
 
-        foreach ($this->content['profilesIds'] as $profileId) {
+        foreach ($this->content['profileIds'] as $profileId) {
             $profiles[] = $this->security->getProfile($profileId);
         }
 
@@ -57,13 +57,13 @@ class User extends Document
      */
     public function setProfiles($profiles)
     {
-        $profilesIds = [];
+        $profileIds = [];
 
         foreach ($profiles as $profile) {
-            $profilesIds[] = $this->extractProfileId($profile);
+            $profileIds[] = $this->extractProfileId($profile);
         }
 
-        $this->content['profilesIds'] = $profilesIds;
+        $this->content['profileIds'] = $profileIds;
 
         return $this;
     }
@@ -76,7 +76,7 @@ class User extends Document
      */
     public function addProfile($profile)
     {
-        $this->content['profilesIds'][] = $this->extractProfileId($profile);
+        $this->content['profileIds'][] = $this->extractProfileId($profile);
 
         return $this;
     }
@@ -98,17 +98,17 @@ class User extends Document
 
     protected function syncProfile()
     {
-        if (!array_key_exists('profilesIds', $this->content)) {
-            $this->content['profilesIds'] = [User::DEFAULT_PROFILE];
+        if (!array_key_exists('profileIds', $this->content)) {
+            $this->content['profileIds'] = [User::DEFAULT_PROFILE];
         }
 
-        $profilesIds = [];
+        $profileIds = [];
 
-        foreach ($this->content['profilesIds'] as $profile) {
-            $profilesIds[] = $this->extractProfileId($profile);
+        foreach ($this->content['profileIds'] as $profile) {
+            $profileIds[] = $this->extractProfileId($profile);
         }
 
-        $this->content['profilesIds'] = $profilesIds;
+        $this->content['profileIds'] = $profileIds;
     }
 
     /**

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -36,10 +36,14 @@ class User extends Document
     /**
      * Returns this user associated profile.
      *
-     * @return Profile[]
+     * @return Profile[]|false
      */
     public function getProfiles()
     {
+        if (!array_key_exists('profileIds', $this->content)) {
+            return [];
+        }
+
         $profiles = [];
 
         foreach ($this->content['profileIds'] as $profileId) {
@@ -76,6 +80,10 @@ class User extends Document
      */
     public function addProfile($profile)
     {
+        if (!array_key_exists('profileIds', $this->content)) {
+            $this->content['profileIds'] = [];
+        }
+
         $this->content['profileIds'][] = $this->extractProfileId($profile);
 
         return $this;
@@ -99,7 +107,7 @@ class User extends Document
     protected function syncProfile()
     {
         if (!array_key_exists('profileIds', $this->content)) {
-            $this->content['profileIds'] = [User::DEFAULT_PROFILE];
+            return false;
         }
 
         $profileIds = [];

--- a/src/config/routes.json
+++ b/src/config/routes.json
@@ -1530,6 +1530,11 @@
       "name": "createUser",
       "route": "/api/1.0/users/_create"
     },
+    "createRestrictedUser": {
+      "method": "post",
+      "name": "createRestrictedUser",
+      "route": "/api/1.0/users/_createRestricted"
+    },
     "deleteProfile": {
       "method": "delete",
       "name": "deleteProfile",

--- a/tests/KuzzleTest.php
+++ b/tests/KuzzleTest.php
@@ -1186,7 +1186,7 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
         $whoAmIResponse = [
             '_id' => 'alovelace',
             '_source' => [
-                'profilesIds' => ['admin'],
+                'profileIds' => ['admin'],
                 'foo' => 'bar'
             ]
         ];

--- a/tests/Security/SecurityTest.php
+++ b/tests/Security/SecurityTest.php
@@ -274,7 +274,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
 
         $userId = uniqid();
         $userContent = [
-            'profilesIds' => ['admin']
+            'profileIds' => ['admin']
         ];
 
         $httpRequest = [
@@ -330,7 +330,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
 
         $userId = uniqid();
         $userContent = [
-            'profilesIds' => ['admin']
+            'profileIds' => ['admin']
         ];
 
         $httpRequest = [
@@ -657,7 +657,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
 
         $userId = uniqid();
         $userContent = [
-            'profilesIds' => ['admin']
+            'profileIds' => ['admin']
         ];
 
         $httpRequest = [
@@ -1206,7 +1206,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $userId = uniqid();
 
         $userContent = [
-            'profilesIds' => [uniqid()]
+            'profileIds' => [uniqid()]
         ];
         $userBaseContent = [
             'foo' => 'bar'

--- a/tests/Security/SecurityTest.php
+++ b/tests/Security/SecurityTest.php
@@ -323,6 +323,62 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($userContent, 'content', $result);
     }
 
+    function testCreateRestrictedUser()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+
+        $userId = uniqid();
+        $userContent = [
+            'some' => 'content'
+        ];
+
+        $httpRequest = [
+            'route' => '/api/1.0/users/_createRestricted',
+            'method' => 'POST',
+            'request' => [
+                'metadata' => [],
+                'controller' => 'security',
+                'action' => 'createRestrictedUser',
+                'requestId' => $requestId,
+                '_id' => $userId,
+                'body' => $userContent
+            ]
+        ];
+        $saveResponse = [
+            '_id' => $userId,
+            '_source' => $userContent,
+            '_version' => 1
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $saveResponse
+        ];
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        /**
+         * @var Kuzzle $kuzzle
+         */
+        $security = new Security($kuzzle);
+
+        $result = $security->createRestrictedUser($userId, $userContent, ['requestId' => $requestId]);
+
+        $this->assertInstanceOf('Kuzzle\Security\User', $result);
+        $this->assertAttributeEquals($userId, 'id', $result);
+        $this->assertAttributeEquals($userContent, 'content', $result);
+    }
+
     function testCreateOrReplaceUser()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;

--- a/tests/Security/UserTest.php
+++ b/tests/Security/UserTest.php
@@ -7,6 +7,38 @@ use Kuzzle\Security\Security;
 
 class UserTest extends \PHPUnit_Framework_TestCase
 {
+    function testEmptyGetProfiles()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $security = new Security($kuzzle);
+        $user = new User($security, '', []);
+
+        $this->assertEquals($user->getProfiles(), []);
+    }
+
+    function testAddProfile()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $security = new Security($kuzzle);
+        $user = new User($security, '', []);
+
+        $this->assertEquals($user, $user->addProfile('myProfile'));
+    }
+
     function testSave()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;

--- a/tests/Security/UserTest.php
+++ b/tests/Security/UserTest.php
@@ -14,7 +14,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
 
         $userId = uniqid();
         $userContent = [
-            'profilesIds' => ['admin']
+            'profileIds' => ['admin']
         ];
 
         $httpRequest = [
@@ -64,7 +64,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($userId, 'id', $result);
         $this->assertAttributeEquals($userContent, 'content', $result);
 
-        $profile = new Profile($security, $userContent['profilesIds'][0]);
+        $profile = new Profile($security, $userContent['profileIds'][0]);
         $user->setProfiles([$profile]);
         $result = $user->save(['requestId' => $requestId]);
 
@@ -81,7 +81,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $userId = uniqid();
 
         $userContent = [
-            'profilesIds' => [uniqid()]
+            'profileIds' => [uniqid()]
         ];
         $userBaseContent = [
             'foo' => 'bar'


### PR DESCRIPTION
fix #23

- Add `createRestrictedUser` in `Security`
- Removed default profile from User initialization (not consistant with other SDKs)