### PR TITLE
Collection.createDocument: rename the updateIfExist option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzleio/kuzzle-sdk",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Official PHP SDK for Kuzzle",
   "homepage": "http://kuzzle.io",
   "license": "Apache-2.0",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzleio/kuzzle-sdk",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Official PHP SDK for Kuzzle",
   "homepage": "http://kuzzle.io",
   "license": "Apache-2.0",

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -180,7 +180,7 @@ class Collection
         if (array_key_exists('ifExist', $options)) {
             if ($options['ifExist'] == 'replace') {
                 $action = 'createOrReplace';
-            } elseif ($options['ifExist'] !== 'error') {
+            } elseif ($options['ifExist'] != 'error') {
                 throw new InvalidArgumentException('Invalid "ifExist" option value: ' . $options['ifExist']);
             }
         }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -3,6 +3,7 @@
 namespace Kuzzle;
 
 use Kuzzle\Util\SearchResult;
+use InvalidArgumentException;
 
 /**
  * Class Collection
@@ -169,14 +170,19 @@ class Collection
      * @param array $options Optional parameters
      *
      * @return Document
+     * @throws InvalidArgumentException
      */
     public function createDocument($document, $id = '', array $options = [])
     {
         $action = 'create';
         $data = [];
 
-        if (array_key_exists('updateIfExist', $options)) {
-            $action = $options['updateIfExist'] ? 'createOrReplace' : 'create';
+        if (array_key_exists('ifExist', $options)) {
+            if ($options['ifExist'] == 'replace') {
+                $action = 'createOrReplace';
+            } elseif ($options['ifExist'] !== 'error') {
+                throw new InvalidArgumentException('Invalid "ifExist" option value: ' . $options['ifExist']);
+            }
         }
 
         if ($document instanceof Document) {

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -404,12 +404,41 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
 
         $documentObject = new \Kuzzle\Document($dataCollection, $documentId, $documentContent);
 
-        $document = $dataCollection->createDocument($documentObject, '', ['updateIfExist' => true, 'requestId' => $requestId]);
+        $document = $dataCollection->createDocument($documentObject, '', ['ifExist' => 'replace', 'requestId' => $requestId]);
 
         $this->assertInstanceOf('Kuzzle\Document', $document);
         $this->assertAttributeEquals($documentId, 'id', $document);
         $this->assertAttributeEquals($documentContent, 'content', $document);
         $this->assertAttributeEquals(1, 'version', $document);
+    }
+
+    function testCreateDocumentInvalidOption()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $documentId = uniqid();
+        $documentContent = [
+            'foo' => 'bar'
+        ];
+
+        $kuzzle = $kuzzle = new \Kuzzle\Kuzzle($url);
+
+        /**
+         * @var Kuzzle $kuzzle
+         */
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        try {
+          $document = $dataCollection->createDocument($documentContent, $documentId, ['ifExist' => 'foobar', 'requestId' => $requestId]);
+          $this->fail('DataCollectionTest::testCreateDocumentInvalidOption => should have thrown');
+        }
+        catch(Exception $e) {
+          $this->assertInstanceOf('InvalidArgumentException', $e);
+          $this->assertEquals('Invalid "ifExist" option value: foobar', $e->getMessage());
+        }
     }
 
     function testDeleteDocument()


### PR DESCRIPTION
# Description

The `Collection.createDocument` method accepts a `updateIfExist` option.
Since this option really replaces the document if it already exists, it is dangerously confusing.

This PR change this option name to `ifExist` and its accepted value to one of these 2 values: `error` (default) or `replace`
If an invalid value is provided, the method throws an `InvalidArgumentException` exception.

# Solved issue

#54 
