### PR TITLE
Align SearchResult and scroll with other SDKs

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -89,12 +89,13 @@ class Collection
      * Retrieves next result of a search with scroll query.
      *
      * @param string $scrollId
+     * @param string $scroll
      * @param array $options (optional) arguments
      * @param array $filters (optional) original filters
      * @return SearchResult
      * @throws \Exception
      */
-    public function scroll($scrollId, array $options = [], array $filters = [])
+    public function scroll($scrollId, $scroll, array $options = [], array $filters = [])
     {
         $options['httpParams'] = [':scrollId' => $scrollId];
 
@@ -104,9 +105,11 @@ class Collection
             throw new \Exception('Collection.scroll: scrollId is required');
         }
 
-        if (!$options['scroll']) {
+        if (!$scroll) {
             throw new \Exception('Collection.scroll: scroll is required');
         }
+
+        $options['scroll'] = $scroll;
 
         $response = $this->kuzzle->query(
             $this->kuzzle->buildQueryArgs('document', 'scroll'),
@@ -324,7 +327,7 @@ class Collection
             foreach ($searchResult->getDocuments() as $document) {
                 $documents[] = $document;
             }
-            $searchResult = $searchResult->getNext();
+            $searchResult = $searchResult->fetchNext();
         }
 
         return $documents;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -96,7 +96,7 @@ class Collection
      * @return SearchResult
      * @throws \Exception
      */
-    public function scroll($scrollId, $scroll, array $options = [], array $filters = [])
+    public function scroll($scrollId, array $options = [], array $filters = [])
     {
         $options['httpParams'] = [':scrollId' => $scrollId];
 
@@ -105,12 +105,6 @@ class Collection
         if (!$scrollId) {
             throw new \Exception('Collection.scroll: scrollId is required');
         }
-
-        if (!$scroll) {
-            throw new \Exception('Collection.scroll: scroll is required');
-        }
-
-        $options['scroll'] = $scroll;
 
         $response = $this->kuzzle->query(
             $this->kuzzle->buildQueryArgs('document', 'scroll'),

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -80,7 +80,8 @@ class Collection
             $response['result']['total'],
             $response['result']['hits'],
             array_key_exists('aggregations', $response['result']) ? $response['result']['aggregations'] : [],
-            ['filters' => $filters, 'options' => $options],
+            $options,
+            $filters,
             array_key_exists('previous', $options) ? $options['previous'] : null
         );
     }
@@ -131,7 +132,8 @@ class Collection
             $response['result']['total'],
             $response['result']['hits'],
             array_key_exists('aggregations', $response['result']) ? $response['result']['aggregations'] : [],
-            ['filters' => $filters, 'options' => $options],
+            $options,
+            $filters,
             array_key_exists('previous', $options) ? $options['previous'] : null
         );
     }

--- a/src/MemoryStorage.php
+++ b/src/MemoryStorage.php
@@ -254,11 +254,23 @@ class MemoryStorage
     
     protected $kuzzle;
 
+    /**
+     * MemoryStorage constructor.
+     *
+     * @param Kuzzle $kuzzle
+     */
     public function __construct(Kuzzle $kuzzle)
     {
         $this->kuzzle = $kuzzle;
     }
 
+    /**
+     * Magic __call function, acts as proxy
+     *
+     * @param $command
+     * @param $arguments
+     * @return array
+     */
     public function __call($command, $arguments)
     {
         if (!array_key_exists($command, $this->COMMANDS)) {

--- a/src/Security/Document.php
+++ b/src/Security/Document.php
@@ -2,6 +2,10 @@
 
 namespace Kuzzle\Security;
 
+/**
+ * Class Document
+ * @package Kuzzle\Security
+ */
 abstract class Document
 {
     protected $deleteActionName = '';
@@ -78,7 +82,7 @@ abstract class Document
      *
      * @param array $content New profile content
      * @param array $options Optional parameters
-     * @return Profile
+     * @return Document
      */
     public function update(array $content, array $options = [])
     {
@@ -102,7 +106,7 @@ abstract class Document
      * Creates or replaces the profile in Kuzzle’s database layer.
      *
      * @param array $options Optional parameters
-     * @return Profile
+     * @return Document
      */
     public function save(array $options = [])
     {

--- a/src/Security/Policy.php
+++ b/src/Security/Policy.php
@@ -2,6 +2,10 @@
 
 namespace Kuzzle\Security;
 
+/**
+ * Class Policy
+ * @package Kuzzle\Security
+ */
 class Policy
 {
     /**
@@ -96,7 +100,7 @@ class Policy
      */
     public function getRole()
     {
-        return $this->profile->getSecurity()->getRole($this->roleId);
+        return $this->profile->getSecurity()->fetchRole($this->roleId);
     }
 
     /**

--- a/src/Security/Profile.php
+++ b/src/Security/Profile.php
@@ -114,6 +114,9 @@ class Profile extends Document
         return $data;
     }
 
+    /**
+     *
+     */
     protected function syncPolicies()
     {
         if (!array_key_exists('policies', $this->content)) {

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -47,7 +47,7 @@ class User extends Document
         $profiles = [];
 
         foreach ($this->content['profileIds'] as $profileId) {
-            $profiles[] = $this->security->getProfile($profileId);
+            $profiles[] = $this->security->fetchProfile($profileId);
         }
 
         return $profiles;
@@ -104,6 +104,9 @@ class User extends Document
         return $this;
     }
 
+    /**
+     * @return bool
+     */
     protected function syncProfile()
     {
         if (!array_key_exists('profileIds', $this->content)) {
@@ -117,6 +120,8 @@ class User extends Document
         }
 
         $this->content['profileIds'] = $profileIds;
+
+        return true;
     }
 
     /**

--- a/src/Util/CurlRequest.php
+++ b/src/Util/CurlRequest.php
@@ -2,8 +2,16 @@
 
 namespace Kuzzle\Util;
 
+/**
+ * Class CurlRequest
+ * @package Kuzzle\Util
+ */
 class CurlRequest implements RequestInterface
 {
+    /**
+     * @param array $parameters
+     * @return array
+     */
     public function execute(array $parameters = [])
     {
         $url = '';

--- a/src/Util/ProfilesSearchResult.php
+++ b/src/Util/ProfilesSearchResult.php
@@ -4,6 +4,10 @@ namespace Kuzzle\Util;
 
 use Kuzzle\Security\Profile;
 
+/**
+ * Class ProfilesSearchResult
+ * @package Kuzzle\Util
+ */
 class ProfilesSearchResult
 {
     /**

--- a/src/Util/RequestInterface.php
+++ b/src/Util/RequestInterface.php
@@ -2,7 +2,15 @@
 
 namespace Kuzzle\Util;
 
+/**
+ * Interface RequestInterface
+ * @package Kuzzle\Util
+ */
 interface RequestInterface
 {
+    /**
+     * @param array $parameters
+     * @return array
+     */
     public function execute(array $parameters = []);
 }

--- a/src/Util/RolesSearchResult.php
+++ b/src/Util/RolesSearchResult.php
@@ -4,6 +4,10 @@ namespace Kuzzle\Util;
 
 use Kuzzle\Security\Role;
 
+/**
+ * Class RolesSearchResult
+ * @package Kuzzle\Util
+ */
 class RolesSearchResult
 {
     /**

--- a/src/Util/SearchResult.php
+++ b/src/Util/SearchResult.php
@@ -59,7 +59,7 @@ class SearchResult
      * @param SearchResult $previous
      * @internal param array $searchArgs
      */
-    public function __construct(Collection $collection, $total, array $documents, array $aggregations = [], array $options, array $fiters, SearchResult $previous = null)
+    public function __construct(Collection $collection, $total, array $documents, array $aggregations = [], array $options = [], array $fiters = [], SearchResult $previous = null)
     {
         $this->collection = $collection;
         $this->total = $total;

--- a/src/Util/SearchResult.php
+++ b/src/Util/SearchResult.php
@@ -35,7 +35,12 @@ class SearchResult
     /**
      * @var array
      */
-    private $searchArgs = [];
+    private $options = [];
+
+    /**
+     * @var array
+     */
+    private $filters = [];
 
     /**
      * @var int
@@ -49,16 +54,19 @@ class SearchResult
      * @param integer $total
      * @param Document[] $documents
      * @param array $aggregations
-     * @param array $searchArgs
+     * @param array $options
+     * @param array $fiters
      * @param SearchResult $previous
+     * @internal param array $searchArgs
      */
-    public function __construct(Collection $collection, $total, array $documents, array $aggregations = [], array $searchArgs = [], SearchResult $previous = null)
+    public function __construct(Collection $collection, $total, array $documents, array $aggregations = [], array $options, array $fiters, SearchResult $previous = null)
     {
         $this->collection = $collection;
         $this->total = $total;
         $this->documents = $documents;
         $this->aggregations = $aggregations;
-        $this->searchArgs = $searchArgs;
+        $this->options = $options;
+        $this->filters = $fiters;
         $this->fetchedDocuments = count($documents) + ($previous instanceof SearchResult ? $previous->fetchedDocuments : 0);
 
         return $this;
@@ -99,9 +107,17 @@ class SearchResult
     /**
      * @return array
      */
-    public function getSearchArgs()
+    public function getOptions()
     {
-        return $this->searchArgs;
+        return $this->options;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFilters()
+    {
+        return $this->filters;
     }
 
     /**
@@ -119,13 +135,13 @@ class SearchResult
     {
         $searchResult = null;
 
-        if (array_key_exists('scrollId', $this->searchArgs['options']) && array_key_exists('scroll', $this->searchArgs['options'])) {
+        if (array_key_exists('scrollId', $this->options) && array_key_exists('scroll', $this->options)) {
             // retrieve next results with scroll if original search use it
             if ($this->fetchedDocuments >= $this->getTotal()) {
                 return null;
             }
 
-            $options = $this->searchArgs['options'];
+            $options = $this->options;
             $options['previous'] = $this;
 
             if (array_key_exists('from', $options)) {
@@ -140,12 +156,12 @@ class SearchResult
                 $options['scrollId'],
                 $options['scroll'],
                 $options,
-                $this->searchArgs['filters']
+                $this->filters
             );
-        } else if (array_key_exists('from', $this->searchArgs['options']) && array_key_exists('size', $this->searchArgs['options'])) {
+        } else if (array_key_exists('from', $this->options) && array_key_exists('size', $this->options)) {
             // retrieve next results with  from/size if original search use it
-            $filters = $this->searchArgs['filters'];
-            $options = $this->searchArgs['options'];
+            $filters = $this->filters;
+            $options = $this->options;
             $options['previous'] = $this;
 
             $options['from'] += $options['size'];

--- a/src/Util/SearchResult.php
+++ b/src/Util/SearchResult.php
@@ -9,8 +9,6 @@ use Kuzzle\Document;
 /**
  * Class SearchResult
  * @package Kuzzle\Util
- *
- * @todo: Implement Iterator interface
  */
 class SearchResult
 {
@@ -38,6 +36,11 @@ class SearchResult
      * @var array
      */
     private $searchArgs = [];
+
+    /**
+     * @var int
+     */
+    private $fetchedDocuments = 0;
 
     /**
      * SearchResult constructor.
@@ -78,6 +81,14 @@ class SearchResult
     }
 
     /**
+     * @return Collection
+     */
+    public function getCollection()
+    {
+        return $this->collection;
+    }
+
+    /**
      * @return array
      */
     public function getAggregations()
@@ -86,13 +97,29 @@ class SearchResult
     }
 
     /**
+     * @return array
+     */
+    public function getSearchArgs()
+    {
+        return $this->searchArgs;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFetchedDocuments()
+    {
+        return $this->fetchedDocuments;
+    }
+
+    /**
      * @return SearchResult
      */
-    public function getNext()
+    public function fetchNext()
     {
         $searchResult = null;
 
-        if (array_key_exists('scrollId', $this->searchArgs['options'])) {
+        if (array_key_exists('scrollId', $this->searchArgs['options']) && array_key_exists('scroll', $this->searchArgs['options'])) {
             // retrieve next results with scroll if original search use it
             if ($this->fetchedDocuments >= $this->getTotal()) {
                 return null;
@@ -100,10 +127,6 @@ class SearchResult
 
             $options = $this->searchArgs['options'];
             $options['previous'] = $this;
-
-            if (array_key_exists('scroll', $this->searchArgs['filters'])) {
-                $options['scroll'] = $this->searchArgs['filters']['scroll'];
-            }
 
             if (array_key_exists('from', $options)) {
                 unset($options['from']);
@@ -115,6 +138,7 @@ class SearchResult
 
             $searchResult = $this->collection->scroll(
                 $options['scrollId'],
+                $options['scroll'],
                 $options,
                 $this->searchArgs['filters']
             );

--- a/src/Util/SearchResult.php
+++ b/src/Util/SearchResult.php
@@ -135,7 +135,7 @@ class SearchResult
     {
         $searchResult = null;
 
-        if (array_key_exists('scrollId', $this->options) && array_key_exists('scroll', $this->options)) {
+        if (array_key_exists('scrollId', $this->options)) {
             // retrieve next results with scroll if original search use it
             if ($this->fetchedDocuments >= $this->getTotal()) {
                 return null;
@@ -154,7 +154,6 @@ class SearchResult
 
             $searchResult = $this->collection->scroll(
                 $options['scrollId'],
-                $options['scroll'],
                 $options,
                 $this->filters
             );

--- a/src/Util/UsersSearchResult.php
+++ b/src/Util/UsersSearchResult.php
@@ -4,6 +4,10 @@ namespace Kuzzle\Util;
 
 use Kuzzle\Security\User;
 
+/**
+ * Class UsersSearchResult
+ * @package Kuzzle\Util
+ */
 class UsersSearchResult
 {
     /**

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -95,6 +95,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;
         $scrollId = uniqid();
+        $scroll = '1m';
         $index = 'index';
         $collection = 'collection';
 
@@ -105,8 +106,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $options = [
-            'requestId' => uniqid(),
-            'scroll' => '1m'
+            'requestId' => uniqid()
         ];
 
         // mock http request
@@ -161,7 +161,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $searchResult = $dataCollection->scroll($scrollId, $options);
+        $searchResult = $dataCollection->scroll($scrollId, $scroll, $options);
 
         $this->assertInstanceOf('Kuzzle\Util\SearchResult', $searchResult);
         $this->assertEquals(2, $searchResult->getTotal());

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -9,6 +9,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $url = KuzzleTest::FAKE_KUZZLE_HOST;
         $requestId = uniqid();
         $index = 'index';
+        $options = ['requestId' => $requestId];
         $collection = 'collection';
         $filter = [
             'query' => [
@@ -76,10 +77,13 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $searchResult = $dataCollection->search($filter, ['requestId' => $requestId]);
+        $searchResult = $dataCollection->search($filter, $options);
 
         $this->assertInstanceOf('Kuzzle\Util\SearchResult', $searchResult);
         $this->assertEquals(2, $searchResult->getTotal());
+        $this->assertEquals($options, $searchResult->getOptions());
+        $this->assertEquals($filter, $searchResult->getFilters());
+        $this->assertEquals(2, $searchResult->getFetchedDocuments());
 
         $documents = $searchResult->getDocuments();
         $this->assertInstanceOf('Kuzzle\Document', $documents[0]);

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -99,7 +99,6 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;
         $scrollId = uniqid();
-        $scroll = '1m';
         $index = 'index';
         $collection = 'collection';
 
@@ -110,7 +109,8 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $options = [
-            'requestId' => uniqid()
+            'requestId' => uniqid(),
+            'scroll' => '1m'
         ];
 
         // mock http request
@@ -165,7 +165,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $searchResult = $dataCollection->scroll($scrollId, $scroll, $options);
+        $searchResult = $dataCollection->scroll($scrollId, $options);
 
         $this->assertInstanceOf('Kuzzle\Util\SearchResult', $searchResult);
         $this->assertEquals(2, $searchResult->getTotal());


### PR DESCRIPTION
Breaking changes:

* Align `SearchResult` constructor signature with other SDKs
* Rename `next` into `fetchNext`

Other changes:

* Add getters on `SearchResult`

documentation: https://github.com/kuzzleio/documentation/pull/139
fix: https://github.com/kuzzleio/sdk/issues/13