### PR TITLE
Collection.scroll is now a GET method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Official Kuzzle PHP SDK
 ======
 
-This SDK version is compatible with Kuzzle 1.0.0-RC9 and higher
+This SDK version is compatible with Kuzzle 1.0.0-RC9.5 and higher
 
 ## About Kuzzle
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzleio/kuzzle-sdk",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Official PHP SDK for Kuzzle",
   "homepage": "http://kuzzle.io",
   "license": "Apache-2.0",

--- a/src/config/routes.json
+++ b/src/config/routes.json
@@ -104,7 +104,7 @@
     "scroll": {
       "name": "scroll",
       "route": "/_scroll/:scrollId",
-      "method": "post"
+      "method": "get"
     },
     "get": {
       "name": "get",

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -118,7 +118,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                 'metadata' => [],
                 'requestId' => $options['requestId']
             ],
-            'method' => 'POST',
+            'method' => 'GET',
             'query_parameters' => [
                 'scroll' => '1m'
             ]
@@ -611,7 +611,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
 
         $httpScrollRequest = [
             'route' => '/_scroll/' . $scrollId,
-            'method' => 'POST',
+            'method' => 'GET',
             'request' => [
                 'metadata' => [],
                 'controller' => 'document',


### PR DESCRIPTION
# Description

Following https://github.com/kuzzleio/kuzzle/pull/709, the `scroll` method is now accessible through a HTTP GET call. Updating this SDK is required to use this method with the new version of Kuzzle.