### PR TITLE
Standardize memory storage

### DIFF
--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -539,6 +539,10 @@ class Kuzzle
                 }
             }
 
+            if (isset($options['query_parameters'])) {
+                $httpParams['query_parameters'] = array_merge($httpParams['query_parameters'], $options['query_parameters']);
+            }
+
             if (array_key_exists('refresh', $options)) {
                 $httpParams['query_parameters']['refresh'] = $options['refresh'];
             }

--- a/src/MemoryStorage.php
+++ b/src/MemoryStorage.php
@@ -225,11 +225,11 @@ class MemoryStorage
         'setnx' => ['required' => ['_id', 'value']],
         'sinter' => ['getter' => true, 'required' => ['keys']],
         'sinterstore' => ['required' => ['destination', 'keys']],
-        'sismember' => ['required' => ['_id', 'member']],
+        'sismember' => ['getter' => true, 'required' => ['_id', ':member']],
         'smembers' => ['getter' => true, 'required' => ['_id']],
         'smove' => ['required' => ['_id', 'destination', 'member']],
-        'sort' => ['getter' => true, 'required' => ['_id'], 'opts' => ['alpha', 'by', 'direction', 'get', 'limit']],
-        'spop' => ['required' => ['_id'], 'mapResults' => 'mapStringToArray'],
+        'sort' => ['required' => ['_id'], 'opts' => ['alpha', 'by', 'direction', 'get', 'limit']],
+        'spop' => ['required' => ['_id'], 'opts' => ['count'], 'mapResults' => 'mapStringToArray'],
         'srandmember' => ['getter' => true, 'required' => ['_id'], 'opts' => ['count'], 'mapResults' => 'mapStringToArray'],
         'srem' => ['required' => ['_id', 'members']],
         'sscan' => ['getter' => true, 'required' => ['_id', 'cursor'], 'opts' => ['match', 'count']],
@@ -237,10 +237,11 @@ class MemoryStorage
         'sunion' => ['getter' => true, 'required' => ['keys']],
         'sunionstore' => ['required' => ['destination', 'keys']],
         'time' => ['getter' => true, 'mapResults' => 'mapArrayStringToArrayInt'],
-        'touch' => ['required' => 'keys'],
+        'touch' => ['required' => ['keys']],
         'ttl' => ['getter' => 'true', 'required' => ['_id']],
         'type' => ['getter' => 'true', 'required' => ['_id']],
         'zadd' => ['required' => ['_id', 'elements'], 'opts' => ['nx', 'xx', 'ch', 'incr']],
+        'zcard' => ['getter' => true, 'required' => ['_id']],
         'zcount' => ['getter' => true, 'required' => ['_id', 'min', 'max']],
         'zincrby' => ['required' => ['_id', 'member', 'value']],
         'zinterstore' => ['required' => ['_id', 'keys'], 'opts' => ['weights', 'aggregate']],
@@ -258,7 +259,7 @@ class MemoryStorage
             'opts' => 'assignZrangeOptions',
             'mapResults' => 'mapZrangeResults'
         ],
-        'zrank' => ['getter' => true, 'required' => ['_id', 'member']],
+        'zrank' => ['getter' => true, 'required' => ['_id', ':member']],
         'zrem' => ['required' => ['_id', 'members']],
         'zremrangebylex' => ['required' => ['_id', 'min', 'max']],
         'zremrangebyrank' => ['required' => ['_id', 'start', 'stop']],
@@ -269,16 +270,16 @@ class MemoryStorage
             'opts' => 'assignZrangeOptions',
             'mapResults' => 'mapZrangeResults'
         ],
-        'zrevangebylex' => ['getter' => true, 'required' => ['_id', 'min', 'max'], 'opts' => ['limit']],
+        'zrevrangebylex' => ['getter' => true, 'required' => ['_id', 'min', 'max'], 'opts' => ['limit']],
         'zrevrangebyscore' => [
             'getter' => true,
             'required' => ['_id', 'min', 'max'],
             'opts' => 'assignZrangeOptions',
             'mapResults' => 'mapZrangeResults'
         ],
-        'zrevrank' => ['getter' => true, 'required' => ['_id', 'member']],
+        'zrevrank' => ['getter' => true, 'required' => ['_id', ':member']],
         'zscan' => ['getter' => true, 'required' => ['_id', 'cursor'], 'opts' => ['match', 'count']],
-        'zscore' => ['getter' => true, 'required' => ['_id', 'member']],
+        'zscore' => ['getter' => true, 'required' => ['_id', ':member']],
         'zunionstore' => ['required' => ['_id', 'keys'], 'opts' => ['weights', 'aggregate']]
     ];
 
@@ -444,7 +445,7 @@ class MemoryStorage
      */
     private function assignZrangeOptions(&$options)
     {
-        $options['query_parameters']['options'] = ['withscores'];
+        $options['query_parameters']['options'] = 'withscores';
 
         if (isset($options['limit'])) {
             $options['query_parameters']['limit'] = implode(',', $options['limit']);
@@ -597,7 +598,8 @@ class MemoryStorage
      * @param $results
      * @return float
      */
-    private function mapStringToFloat($results) {
+    private function mapStringToFloat($results)
+    {
         return floatval($results);
     }
 }

--- a/src/MemoryStorage.php
+++ b/src/MemoryStorage.php
@@ -279,7 +279,7 @@ class MemoryStorage
         ],
         'zrevrank' => ['getter' => true, 'required' => ['_id', ':member']],
         'zscan' => ['getter' => true, 'required' => ['_id', 'cursor'], 'opts' => ['match', 'count']],
-        'zscore' => ['getter' => true, 'required' => ['_id', ':member']],
+        'zscore' => ['getter' => true, 'required' => ['_id', ':member'], 'mapResults' => 'mapStringToFloat'],
         'zunionstore' => ['required' => ['_id', 'keys'], 'opts' => ['weights', 'aggregate']]
     ];
 

--- a/src/MemoryStorage.php
+++ b/src/MemoryStorage.php
@@ -327,7 +327,7 @@ class MemoryStorage
             throw new InvalidArgumentException('MemoryStorage.' . $command . ': Invalid optional parameter (expected an associative array)');
         }
 
-        if ($argsLeft == 1) {
+        if ($argsLeft === 1) {
             $options = array_merge($options, array_shift($arguments));
 
             if (isset($this->COMMANDS[$command]['opts'])) {

--- a/src/MemoryStorage.php
+++ b/src/MemoryStorage.php
@@ -9,71 +9,103 @@ use InvalidArgumentException;
  * @package kuzzleio/kuzzle-sdk
  *
  * @method append
- * @method bgrewriteaof
- * @method bgsave
  * @method bitcount
  * @method bitop
  * @method bitpos
- * @method blpop
- * @method brpoplpush
  * @method dbsize
+ * @method decr
  * @method decrby
  * @method del
- * @method discard
- * @method exec
  * @method exists
  * @method expire
  * @method expireat
  * @method flushdb
+ * @method geoadd
+ * @method geodist
+ * @method geohash
+ * @method geopos
+ * @method georadius
+ * @method georadiusbymember
+ * @method get
  * @method getbit
  * @method getrange
+ * @method getset
  * @method hdel
  * @method hexists
+ * @method hget
+ * @method hgetall
  * @method hincrby
+ * @method hincrbyfloat
+ * @method hkeys
+ * @method hlen
+ * @method hmget
  * @method hmset
+ * @method hscan
  * @method hset
- * @method info
+ * @method hsetnx
+ * @method hstrlen
+ * @method hvals
+ * @method incr
+ * @method incrby
+ * @method incrbyfloat
  * @method keys
- * @method lastsave
  * @method lindex
  * @method linsert
+ * @method llen
+ * @method lpop
  * @method lpush
+ * @method lpushx
  * @method lrange
  * @method lrem
  * @method lset
  * @method ltrim
+ * @method mget
  * @method mset
- * @method multi
+ * @method msetnx
  * @method object
+ * @method persist
  * @method pexpire
  * @method pexpireat
  * @method pfadd
+ * @method pfcount
  * @method pfmerge
  * @method ping
  * @method psetex
- * @method publish
+ * @method pttl
  * @method randomkey
  * @method rename
  * @method renamenx
- * @method restore
+ * @method rpop
  * @method rpoplpush
+ * @method rpush
+ * @method rpushx
  * @method sadd
- * @method save
- * @method set
+ * @method scan
+ * @method scard
+ * @method sdiff
  * @method sdiffstore
- * @method setbit
+ * @method set
  * @method setex
- * @method setrange
+ * @method setnx
+ * @method sinter
  * @method sinterstore
  * @method sismember
+ * @method smembers
  * @method smove
  * @method sort
  * @method spop
+ * @method srandmember
  * @method srem
+ * @method sscan
+ * @method strlen
+ * @method sunion
  * @method sunionstore
- * @method unwatch
- * @method wait
+ * @method time
+ * @method touch
+ * @method ttl
+ * @method type
  * @method zadd
+ * @method zcard
  * @method zcount
  * @method zincrby
  * @method zinterstore
@@ -81,177 +113,174 @@ use InvalidArgumentException;
  * @method zrange
  * @method zrangebylex
  * @method zrangebyscore
+ * @method zrank
  * @method zrem
  * @method zremrangebylex
  * @method zremrangebyscore
  * @method zrevrangebylex
+ * @method zrevrange
  * @method zrevrangebyscore
  * @method zrevrank
- * @method zcard
- * @method type
- * @method ttl
- * @method strlen
- * @method smembers
- * @method scard
- * @method rpop
- * @method pttl
- * @method persist
- * @method lpop
- * @method llen
- * @method incr
- * @method hvals
- * @method hstrlen
- * @method hlen
- * @method hkeys
- * @method hgetall
- * @method dump
- * @method get
- * @method decr
- * @method lpushx
- * @method getset
- * @method watch
- * @method sunion
- * @method sinter
- * @method sdiff
- * @method pfcount
- * @method mget
- * @method incrbyfloat
- * @method incrby
- * @method brpop
- * @method hget
- * @method hmget
- * @method hsetnx
- * @method msetnx
- * @method rpush
- * @method hincrbyfloat
- * @method srandmember
- * @method zrevrange
+ * @method zscan
  * @method zscore
+ * @method zunionstore
  */
 class MemoryStorage
 {
     private $COMMANDS = [
-        "append" => ["id", "value"],
-        "bgrewriteaof" => [],
-        "bgsave" => [],
-        "bitcount" => ["id", "start", "end"],
-        "bitop" => ["operation", "destkey", ["id", "keys"]],
-        "bitpos" => ["id", "bit", ["__opts__" => ["start", "end"]]],
-        "blpop" => [["id", "keys"], "timeout"],
-        "brpoplpush" => ["source", "destination"],
-        "dbsize" => [],
-        "decrby" => ["id", "value"],
-        "del" => [["id", "keys"]],
-        "discard" => [],
-        "exec" => [],
-        "exists" => [["id", "keys"]],
-        "expire" => ["id", "seconds"],
-        "expireat" => ["id", "timestamp"],
-        "flushdb" => [],
-        "getbit" => ["id", "offset"],
-        "getrange" => ["id", "start", "end"],
-        "hdel" => ["id", ["field", "fields"]],
-        "hexists" => ["id", "field"],
-        "hincrby" => ["id", "field", "value"],
-        "hmset" => ["id", "values"],
-        "hset" => ["id", "field", "value"],
-        "info" => ["section"],
-        "keys" => ["pattern"],
-        "lastsave" => [],
-        "lindex" => ["id", "idx"],
-        "linsert" => ["id", "position", "pivot", "value"],
-        "lpush" => ["id", ["value", "values"]],
-        "lrange" => ["id", "start", "stop"],
-        "lrem" => ["id", "count", "value"],
-        "lset" => ["id", "idx", "value"],
-        "ltrim" => ["id", "start", "stop"],
-        "mset" => ["values"],
-        "multi" => [],
-        "object" => ["subcommand", "args"],
-        "pexpire" => ["id", "milliseconds"],
-        "pexpireat" => ["id", "timestamp"],
-        "pfadd" => ["id", ["element", "elements"]],
-        "pfmerge" => ["destkey", ["sourcekey", "sourcekeys"]],
-        "ping" => [],
-        "psetex" => ["id", "milliseconds", "value"],
-        "publish" => ["channel", "message"],
-        "randomkey" => [],
-        "rename" => ["id", "newkey"],
-        "renamenx" => ["id", "newkey"],
-        "restore" => ["id", "ttl", "content"],
-        "rpoplpush" => ["source", "destination"],
-        "sadd" => ["id", ["member", "members"]],
-        "save" => [],
-        "set" => ["id", "value", ["__opts__" => ["ex", "px", "nx", "xx"]]],
-        "sdiffstore" => ["destination", ["id", "keys"]],
-        "setbit" => ["id", "offset", "value"],
-        "setex" => ["id", "seconds", "value"],
-        "setrange" => ["id", "offset", "value"],
-        "sinterstore" => ["destination", ["id", "keys"]],
-        "sismember" => ["id", "member"],
-        "smove" => ["id", "destination", "member"],
-        "sort" => ["id", ["__opts__" => ["by", "offset", "count", "get", "direction", "alpha", "store"]]],
-        "spop" => ["id", "count"],
-        "srem" => ["id", ["member", "members"]],
-        "sunionstore" => ["destination", ["id", "keys"]],
-        "unwatch" => [],
-        "wait" => ["numslaves", "timeout"],
-        "zadd" => ["id", ["__opts__" => ["nx", "xx", "ch", "incr", "score", "member", "members"]]],
-        "zcount" => ["id", "min", "max"],
-        "zincrby" => ["id", "value", "member"],
-        "zinterstore" => ["destination", ["id", "keys"], ["__opts__" => ["weight", "weights", "aggregate"]]],
-        "zlexcount" => ["id", "min", "max"],
-        "zrange" => ["id", "start", "stop", ["__opts__" => ["withscores"]]],
-        "zrangebylex" => ["id", "min", "max", ["__opts__" => ["offset", "count"]]],
-        "zrangebyscore" => ["id", "min", "max", ["__opts__" => ["withscores", "offset", "count"]]],
-        "zrem" => ["id", "member"],
-        "zremrangebylex" => ["id", "min", "max"],
-        "zremrangebyscore" => ["id", "min", "max"],
-        "zrevrangebylex" => ["id", "max", "min", ["__opts__" => ["offset", "count"]]],
-        "zrevrangebyscore" => ["id", "max", "min", ["__opts__" => ["withscores", "offset", "count"]]],
-        "zrevrank" => ["id", "member"],
-        "zcard" => ["id"],
-        "type" => ["id"],
-        "ttl" => ["id"],
-        "strlen" => ["id"],
-        "smembers" => ["id"],
-        "scard" => ["id"],
-        "rpop" => ["id"],
-        "pttl" => ["id"],
-        "persist" => ["id"],
-        "lpop" => ["id"],
-        "llen" => ["id"],
-        "incr" => ["id"],
-        "hvals" => ["id"],
-        "hstrlen" => ["id"],
-        "hlen" => ["id"],
-        "hkeys" => ["id"],
-        "hgetall" => ["id"],
-        "dump" => ["id"],
-        "get" => ["id"],
-        "decr" => ["id"],
-        "lpushx" => ["id", "value"],
-        "getset" => ["id", "value"],
-        "watch" => [["id", "keys"]],
-        "sunion" => [["id", "keys"]],
-        "sinter" => [["id", "keys"]],
-        "sdiff" => [["id", "keys"]],
-        "pfcount" => [["id", "keys"]],
-        "mget" => [["id", "keys"]],
-        "incrbyfloat" => ["id", "value"],
-        "incrby" => ["id", "value"],
-        "brpop" => [["id", "keys"], "timeout"],
-        "hget" => ["id", "field"],
-        "hmget" => ["id", ["field", "fields"]],
-        "hsetnx" => ["id", "field", "value"],
-        "msetnx" => ["values"],
-        "rpush" => ["id", ["value", "values"]],
-        "hincrbyfloat" => ["id", "field", "value"],
-        "srandmember" => ["id", "count"],
-        "zrevrange" => ["id", "start", "stop", ["__opts__" => ["withscores"]]],
-        "zscore" => ["id", "member"]
+        'append' => ['required' => ['_id', 'value']],
+        'bitcount' => ['getter' => true, 'required' => ['_id'], 'opts' => ['start', 'end']],
+        'bitop' => ['required' => ['_id', 'operation', 'keys']],
+        'bitpos' => ['getter' => true, 'required' => ['_id', 'bit'], 'opts' => ['start', 'end']],
+        'dbsize' => ['getter' => true],
+        'decr' => ['required' => ['_id']],
+        'decrby' => ['required' => ['_id', 'value']],
+        'del' => ['required' => ['keys']],
+        'exists' => ['getter' => true, 'required' => ['keys']],
+        'expire' => ['required' => ['_id', 'seconds']],
+        'expireat' => ['required' => ['_id', 'timestamp']],
+        'flushdb' => [],
+        'geoadd' => ['required' => ['_id', 'points']],
+        'geodist' => [
+            'getter' => true,
+            'required' => ['_id', 'member1', 'member2'],
+            'opts' => ['unit'],
+            'mapResults' => 'floatval'
+        ],
+        'geohash' => ['getter' => true, 'required' => ['_id', 'members']],
+        'geopos' => ['getter' => true, 'required' => ['_id', 'members'], 'mapResults' => 'mapGeoposResults'],
+        'georadius' => [
+            'getter' => true,
+            'required' => ['_id', 'lon', 'lat', 'distance', 'unit'],
+            'opts' => 'assignGeoRadiusOptions',
+            'mapResults' => 'mapGeoRadiusResults'
+        ],
+        'georadiusbymember' => [
+            'getter' => true,
+            'required' => ['_id', 'member', 'distance', 'unit'],
+            'opts' => 'assignGeoRadiusOptions',
+            'mapResults' => 'mapGeoRadiusResults'
+        ],
+        'get' => ['getter' => true, 'required' => ['_id']],
+        'getbit' => ['getter' => true, 'required' => ['_id', 'offset']],
+        'getrange' => ['getter' => true, 'required' => ['_id', 'start', 'end']],
+        'getset' => ['required' => ['_id', 'fields']],
+        'hdel' => ['required' => ['_id', 'fields']],
+        'hexists' => ['getter' => true, 'required' => ['_id', 'field']],
+        'hget' => ['getter' => true, 'required' => ['_id', 'field']],
+        'hgetall' => ['getter' => true, 'required' => ['_id'], 'mapResults' => 'mapKeyValueResults'],
+        'hincrby' => ['required' => ['_id', 'field', 'value']],
+        'hincrbyfloat' => ['required' => ['_id', 'field', 'value'], 'mapResults' => 'floatval'],
+        'hkeys' => ['getter' => true, 'required' => ['_id']],
+        'hlen' => ['getter' => true, 'required' => ['_id']],
+        'hmget' => ['getter' => true, 'required' => ['_id', 'fields']],
+        'hmset' => ['required' => ['_id', 'entries']],
+        'hscan' => ['getter' => true, 'required' => ['_id', 'cursor'], 'opts' => ['match', 'count']],
+        'hset' => ['required' => ['_id', 'field', 'value']],
+        'hsetnx' => ['required' => ['_id', 'field', 'value']],
+        'hstrlen' => ['getter' => true, 'required' => ['_id', 'field']],
+        'hvals' => ['getter' => true, 'required' => ['_id']],
+        'incr' => ['required' => ['_id']],
+        'incrby' => ['required' => ['_id', 'value']],
+        'incrbyfloat' => ['required' => ['_id', 'value']],
+        'keys' => ['getter' => true, 'required' => ['pattern']],
+        'lindex' => ['getter' => true, 'required' => ['_id', 'index']],
+        'linsert' => ['required' => ['_id', 'position', 'pivot', 'value']],
+        'llen' => ['getter' => true, 'required' => ['_id']],
+        'lpop' => ['required' => ['_id']],
+        'lpush' => ['required' => ['_id', 'values']],
+        'lpushx' => ['required' => ['_id', 'value']],
+        'lrange' => ['getter' => true, 'required' => ['_id', 'start', 'stop']],
+        'lrem' => ['required' => ['_id', 'count', 'value']],
+        'lset' => ['required' => ['_id', 'index', 'value']],
+        'ltrim' => ['required' => ['_id', 'start', 'stop']],
+        'mget' => ['getter' => true, 'required' => ['keys']],
+        'mset' => ['required' => ['entries']],
+        'msetnx' => ['required' => ['entries']],
+        'object' => ['getter' => true, 'required' => ['_id', 'subcommand']],
+        'persist' => ['required' => ['_id']],
+        'pexpire' => ['required' => ['_id', 'milliseconds']],
+        'pexpireat' => ['required' => ['_id', 'timestamp']],
+        'pfadd' => ['required' => ['_id', 'elements']],
+        'pfcount' => ['getter' => true, 'required' => ['keys']],
+        'pfmerge' => ['required' => ['_id', 'sources']],
+        'ping' => ['getter' => true],
+        'psetex' => ['required' => ['_id', 'value', 'milliseconds']],
+        'pttl' => ['getter' => true, 'required' => ['_id']],
+        'randomkey' => ['getter' => true],
+        'rename' => ['required' => ['_id', 'newkey']],
+        'renamenx' => ['required' => ['_id', 'newkey']],
+        'rpop' => ['required' => ['_id']],
+        'rpoplpush' => ['required' => ['source', 'destination']],
+        'rpush' => ['required' => ['_id', 'values']],
+        'rpushx' => ['required' => ['_id', 'value']],
+        'sadd' => ['required' => ['_id', 'members']],
+        'scan' => ['getter' => true, 'required' => ['cursor'], 'opts' => ['match', 'count']],
+        'scard' => ['getter' => true, 'required' => ['_id']],
+        'sdiff' => ['getter' => true, 'required' => ['_id', 'keys']],
+        'sdiffstore' => ['required' => ['_id', 'keys', 'destination']],
+        'set' => ['required' => ['_id', 'value'], 'opts' => ['ex', 'px', 'nx', 'xx']],
+        'setex' => ['required' => ['_id', 'value', 'seconds']],
+        'setnx' => ['required' => ['_id', 'value']],
+        'sinter' => ['getter' => true, 'required' => ['keys']],
+        'sinterstore' => ['required' => ['destination', 'keys']],
+        'sismember' => ['required' => ['_id', 'member']],
+        'smembers' => ['getter' => true, 'required' => ['_id']],
+        'smove' => ['required' => ['_id', 'destination', 'member']],
+        'sort' => ['getter' => true, 'required' => ['_id'], 'opts' => ['alpha', 'by', 'direction', 'get', 'limit']],
+        'spop' => ['required' => ['_id'], 'mapResults' => 'mapStringToArray'],
+        'srandmember' => ['getter' => true, 'required' => ['_id'], 'opts' => ['count'], 'mapResults' => 'mapStringToArray'],
+        'srem' => ['required' => ['_id', 'members']],
+        'sscan' => ['getter' => true, 'required' => ['_id', 'cursor'], 'opts' => ['match', 'count']],
+        'strlen' => ['getter' => true, 'required' => ['_id']],
+        'sunion' => ['getter' => true, 'required' => ['keys']],
+        'sunionstore' => ['required' => ['destination', 'keys']],
+        'time' => ['getter' => true, 'mapResults' => 'mapArrayStringToArrayInt'],
+        'touch' => ['required' => 'keys'],
+        'ttl' => ['getter' => 'true', 'required' => ['_id']],
+        'type' => ['getter' => 'true', 'required' => ['_id']],
+        'zadd' => ['required' => ['_id', 'elements'], 'opts' => ['nx', 'xx', 'ch', 'incr']],
+        'zcount' => ['getter' => true, 'required' => ['_id', 'min', 'max']],
+        'zincrby' => ['required' => ['_id', 'member', 'value']],
+        'zinterstore' => ['required' => ['_id', 'keys'], 'opts' => ['weights', 'aggregate']],
+        'zlexcount' => ['getter' => true, 'required' => ['_id', 'min', 'max']],
+        'zrange' => [
+            'getter' => true,
+            'required' => ['_id', 'start', 'stop'],
+            'opts' => 'assignZrangeOptions',
+            'mapResults' => 'mapZrangeResults'
+        ],
+        'zrangebylex' => ['getter' => true, 'required' => ['_id', 'min', 'max'], 'opts' => ['limit']],
+        'zrangebyscore' => [
+            'getter' => true,
+            'required' => ['_id', 'min', 'max'],
+            'opts' => 'assignZrangeOptions',
+            'mapResults' => 'mapZrangeResults'
+        ],
+        'zrank' => ['getter' => true, 'required' => ['_id', 'member']],
+        'zrem' => ['required' => ['_id', 'members']],
+        'zremrangebylex' => ['required' => ['_id', 'min', 'max']],
+        'zremrangebyrank' => ['required' => ['_id', 'start', 'stop']],
+        'zremrangebyscore' => ['required' => ['_id', 'min', 'max']],
+        'zrevrange' => [
+            'getter' => true,
+            'required' => ['_id', 'start', 'stop'],
+            'opts' => 'assignZrangeOptions',
+            'mapResults' => 'mapZrangeResults'
+        ],
+        'zrevangebylex' => ['getter' => true, 'required' => ['_id', 'min', 'max'], 'opts' => ['limit']],
+        'zrevrangebyscore' => [
+            'getter' => true,
+            'required' => ['_id', 'min', 'max'],
+            'opts' => 'assignZrangeOptions',
+            'mapResults' => 'mapZrangeResults'
+        ],
+        'zrevrank' => ['getter' => true, 'required' => ['_id', 'member']],
+        'zscan' => ['getter' => true, 'required' => ['_id', 'cursor'], 'opts' => ['match', 'count']],
+        'zscore' => ['getter' => true, 'required' => ['_id', 'member']],
+        'zunionstore' => ['required' => ['_id', 'keys'], 'opts' => ['weights', 'aggregate']]
     ];
-    
+
     protected $kuzzle;
 
     public function __construct(Kuzzle $kuzzle)
@@ -261,53 +290,211 @@ class MemoryStorage
 
     public function __call($command, $arguments)
     {
-        if (!array_key_exists($command, $this->COMMANDS)) {
+        if (!isset($this->COMMANDS[$command])) {
             throw new InvalidArgumentException('MemoryStorage: Command "' . $command . '" not found');
         }
-
-        if (is_array($arguments[count($arguments) - 1])) {
-            $options = array_pop($arguments);
-        } else {
-            $options = [
-                'httpParams' => []
-            ];
+        
+        $data = [];
+        $query = ['controller' => 'memoryStorage', 'action' => $command];
+        $getter = false;
+        
+        if (isset($this->COMMANDS[$command]['getter']) && $this->COMMANDS[$command]['getter'] == true) {
+            $getter = true;
+            $data['body'] = [];
         }
 
-        if (!array_key_exists('httpParams', $options)) {
+        if (isset($this->COMMANDS[$command]['required'])) {
+            foreach($this->COMMANDS[$command]['required'] as $key) {
+                $value = array_shift($arguments);
+
+                if ($value == null) {
+                    throw new InvalidArgumentException('MemoryStorage.' . $command . ': Missing parameter "' . $key . '"');
+                }
+
+                $this->assignParameter($data, $getter, $key, $value);
+            }
+        }
+
+        $argsLeft = count($arguments);
+
+        if ($argsLeft > 1) {
+            throw new InvalidArgumentException('MemoryStorage.' . $command . ': Too many parameters provided');
+        }
+
+        $options = [];
+
+        if (isset($this->COMMANDS[$command]['opts'])) {
+            if ($argsLeft == 1) {
+                $options = array_shift($arguments);
+
+                if (!is_array($options)) {
+                    throw new InvalidArgumentException('MemoryStorage.' . $command . ': Invalid optional parameter (expected an associative array)');
+                }
+
+                if (is_array($this->COMMANDS[$command]['opts'])) {
+                    foreach ($this->COMMANDS[$command]['opts'] as $opt) {
+                        if (isset($options[$opt])) {
+                            $this->assignParameter($data, $getter, $opt, $options[$opt]);
+                            unset($options[$opt]);
+                        }
+                    }
+                }
+            }
+
+            /*
+               Options function mapper does not necessarily should be called
+               whether options have been passed by the client or not
+             */
+            if (is_callable($this->COMMANDS[$command]['opts'])) {
+                call_user_func([$this, $this->COMMANDS[$command]['opts']], $data, $options);
+            }
+        }
+
+        if (!isset($options['httpParams'])) {
             $options['httpParams'] = [];
         }
 
-        $data = [];
-        $query = [
-            'controller' => 'memoryStorage',
-            'action' => $command
-        ];
+        return $this->kuzzle->query($query, $data, $options);
+    }
 
-        foreach ($this->COMMANDS[$command] as $key => $value) {
-            if (!array_key_exists($key, $arguments)) {
-                continue;
-            }
+    /**
+     * Assigns the $key => $value argument to the right
+     * place in the $data structure
+     *
+     * Mutates $data
+     *
+     * @param $data
+     * @param $getter
+     * @param $key
+     * @param $value
+     */
+    private function assignParameter(&$data, $getter, $key, $value) {
+        if ($getter || $key == '_id') {
+            $data[$key] = $value;
+        }
+        else {
+            $data['body'][$key] = $value;
+        }
+    }
 
-            if ($value === 'id') {
-                $data['_id'] = $arguments[$key];
-            } else {
-                if (!array_key_exists('body', $data)) {
-                    $data['body'] = [];
-                }
+    /**
+     * Assign the provided options for the georadius* redis functions
+     * to the request object, as expected by Kuzzle API
+     *
+     * Mutates the provided data and options objects
+     *
+     * @param $data
+     * @param $options
+     */
+    private function assignGeoRadiusOptions (&$data, &$options) {
+        $parsed = [];
 
-                if (is_array($value) && array_key_exists('__opts__', $value)) {
-                    foreach ($value['__opts__'] as $k => $arg) {
-                        if (array_key_exists($arg, $arguments[$key])) {
-                            $data['body'][$arg] = $arguments[$key][$arg];
-                        }
+        $filtered = array_filter($options, function ($opt) {
+            return array_search($opt, ['withcoord', 'withdist', 'count', 'sort']);
+        });
+
+        foreach($options as $opt) {
+            if (array_search($opt, ['withcoord', 'withdist', 'count', 'sort'])) {
+                if ($opt == 'withcoord' || $opt == 'withdist') {
+                    array_push($parsed, $opt);
+                } else if ($opt == 'count' || $opt == 'sort') {
+                    if ($opt == 'count') {
+                        array_push($parsed, 'count');
                     }
-                } else {
-                    $data['body'][$value] = $arguments[$key];
-                    $options['httpParams'][':' . $value] = $arguments[$key];
+
+                    array_push($parsed, $options[$opt]);
                 }
+
+                unset($options[$opt]);
             }
         }
 
-        return $this->kuzzle->query($query, $data, $options);
+        if (count($parsed) > 0) {
+            $data['options'] = $parsed;
+        }
+    }
+
+    /**
+     * Force the WITHSCORES option on z*range* routes
+     *
+     * Mutates the provided data and options objects
+     *
+     * @param data
+     * @param options
+     */
+    private function assignZrangeOptions (&$data, &$options) {
+        &$data['options'] = ['withscores'];
+
+        if (isset($options['limit'])) {
+            $data['limit'] = $options['limit'];
+            unset($options['limit']);
+        }
+    }
+
+    /**
+     * Maps geopos results, from array<array<string>> to array<array<number>>
+     *
+     * @param results
+     * @return array
+     */
+    private function mapGeoposResults($results) {
+        $ret = [];
+
+        foreach($results as $coords) {
+            $point = [];
+
+            foreach($coords as $latlon) {
+                array_push($point, floatval($latlon));
+            }
+
+            array_push($ret, $point);
+        }
+
+        return $ret;
+    }
+
+    /**
+     * Maps georadius results to the format specified in the SDK documentation,
+     * preventing different formats depending on the passed options
+     *
+     * Results can be either an array of point names, or an array
+     * of arrays, each one of them containing the point name,
+     * and additional informations depending on the passed options
+     * (coordinates, distances)
+     *
+     * @param results
+     * @return array
+     */
+    private function mapGeoRadiusResults($results) {
+        // Simple array of point names (no options provided)
+        if (!is_array($results[0])) {
+            return array_map(function (point) {
+                    return ['name' => point];
+            }, $results);
+        }
+
+        return results.map(function (point) {
+                // The point id is always the first item
+                var
+                p = {
+                    name: point[0]
+      },
+      i;
+
+    for (i = 1; i < point.length; i++) {
+        // withcoord result are in an array...
+        if (Array.isArray(point[i])) {
+            p.coordinates = point[i].map(function (coord) {
+                    return parseFloat(coord);
+                });
+        }
+        else {
+            // ... and withdist are not
+            p.distance = parseFloat(point[i]);
+        }
+    }
+
+    return p;
+  });
     }
 }

--- a/src/MemoryStorage.php
+++ b/src/MemoryStorage.php
@@ -8,77 +8,77 @@ use InvalidArgumentException;
  * Class MemoryStorage
  * @package kuzzleio/kuzzle-sdk
  *
- * @method append
- * @method bitcount
- * @method bitop
- * @method bitpos
- * @method dbsize
- * @method decr
- * @method decrby
- * @method del
- * @method exists
- * @method expire
- * @method expireat
- * @method flushdb
- * @method geoadd
- * @method geodist
- * @method geohash
- * @method geopos
- * @method georadius
- * @method georadiusbymember
- * @method get
- * @method getbit
- * @method getrange
- * @method getset
- * @method hdel
- * @method hexists
- * @method hget
- * @method hgetall
- * @method hincrby
- * @method hincrbyfloat
- * @method hkeys
- * @method hlen
- * @method hmget
- * @method hmset
- * @method hscan
- * @method hset
- * @method hsetnx
- * @method hstrlen
- * @method hvals
- * @method incr
- * @method incrby
- * @method incrbyfloat
- * @method keys
- * @method lindex
- * @method linsert
- * @method llen
- * @method lpop
- * @method lpush
- * @method lpushx
- * @method lrange
- * @method lrem
- * @method lset
- * @method ltrim
- * @method mget
- * @method mset
- * @method msetnx
- * @method object
- * @method persist
- * @method pexpire
- * @method pexpireat
- * @method pfadd
- * @method pfcount
- * @method pfmerge
- * @method ping
- * @method psetex
- * @method pttl
- * @method randomkey
- * @method rename
- * @method renamenx
- * @method rpop
- * @method rpoplpush
- * @method rpush
- * @method rpushx
+ * @method int append(string $key, string $value, array $options = NULL)
+ * @method int bitcount(string $key, $options = NULL)
+ * @method int bitop(string $key, string $operation, array $keys, array $options = NULL)
+ * @method int bitpos(string $key, int $bit, array $options = NULL)
+ * @method int dbsize(array $options = NULL)
+ * @method int decr(string $key, array $options = NULL)
+ * @method int decrby(string $key, int $value, array $options = NULL)
+ * @method int del(array $keys, array $options = NULL)
+ * @method int exists(array $keys, array $options = NULL)
+ * @method int expire(string $key, int $seconds, array $options = NULL)
+ * @method int expireat(string $key, int $timestamp, array $options = NULL)
+ * @method string flushdb(array $options = NULL)
+ * @method int geoadd(string $key, array $points, array $options = NULL)
+ * @method float geodist(string $key, string $member1, string $member2, array $options = NULL)
+ * @method array geohash(string $key, array $members, array $options = NULL)
+ * @method array geopos(string $key, array $members, array $options = NULL)
+ * @method array georadius(string $key, float $longitude, float $latitude, float $distance, string $unit, array $options = NULL)
+ * @method array georadiusbymember(string $key, string $member, float $distance, string $unit, array $options = NULL)
+ * @method string get(string $key, array $options = NULL)
+ * @method int getbit(string $key, int $offset, array $options = NULL)
+ * @method string getrange(string $key, int $start, int $end, array $options = NULL)
+ * @method string getset(string $key, string $value, array $options = NULL)
+ * @method int hdel(string $key, array $fields, array $options = NULL)
+ * @method int hexists(string $key, string $field, array $options = NULL)
+ * @method string hget(string $key, string $field, array $options = NULL)
+ * @method array hgetall(string $key, array $options = NULL)
+ * @method int hincrby(string $key, string $field, int $value, array $options = NULL)
+ * @method float hincrbyfloat(string $key, string $field, float $value, array $options = NULL)
+ * @method array hkeys(string $key, array $options = NULL)
+ * @method int hlen(string $key, array $options = NULL)
+ * @method array hmget(string $key, array $fields, array $options = NULL)
+ * @method string hmset(string $key, array $entries, array $options = NULL)
+ * @method array hscan(string $key, int $cursor, array $options = NULL)
+ * @method int hset(string $key, string $field, string $value, array $options = NULL)
+ * @method int hsetnx(string $key, string $field, string $value, array $options = NULL)
+ * @method int hstrlen(string $key, string $field, array $options = NULL)
+ * @method array hvals(string $key, array $options = NULL)
+ * @method int incr(string $key, array $options = NULL)
+ * @method int incrby(string $key, int $value, array $options = NULL)
+ * @method float incrbyfloat(string $key, float $value, array $options = NULL)
+ * @method array keys(string $pattern, array $options = NULL)
+ * @method string lindex(string $key, int $index, array $options = NULL)
+ * @method int linsert(string $key, string $position, string $pivot, string $value, array $options = NULL)
+ * @method int llen(string $key, array $options = NULL)
+ * @method string lpop(string $key, array $options = NULL)
+ * @method int lpush(string $key, array $values, array $options = NULL)
+ * @method int lpushx(string $key, string $value, array $options = NULL)
+ * @method array lrange(string $key, int $start, int $stop, array $options = NULL)
+ * @method int lrem(string $key, int $count, string $value, array $options = NULL)
+ * @method string lset(string $key, int $index, string $value, array $options = NULL)
+ * @method string ltrim(string $key, int $start, int $stop, array $options = NULL)
+ * @method array mget(array $keys, array $options = NULL)
+ * @method string mset(array $entries, array $options = NULL)
+ * @method int msetnx(array $entries, array $options = NULL)
+ * @method string object(string $key, string $subcommand, array $options = NULL)
+ * @method int persist(string $key, array $options = NULL)
+ * @method int pexpire(string $key, int $milliseconds, array $options = NULL)
+ * @method int pexpireat(string $key, int $timestamp, array $options = NULL)
+ * @method int pfadd(string $key, array $elements, array $options = NULL)
+ * @method int pfcount(array $keys, array $options = NULL)
+ * @method string pfmerge(string $key, array $sources, array $options = NULL)
+ * @method string ping(array $options = NULL)
+ * @method string psetex(string $key, string $value, int $milliseconds, array $options = NULL)
+ * @method int pttl(string $key, array $options = NULL)
+ * @method string randomkey(array $options = NULL)
+ * @method string rename(string $key, string $newkey, array $options = NULL)
+ * @method string renamenx(string $key, string $newkey, array $options = NULL)
+ * @method string rpop(string $key, array $options = NULL)
+ * @method string rpoplpush(string $source, string $destination, array $options = NULL)
+ * @method int rpush(string $key, array $values, array $options = NULL)
+ * @method int rpushx(string $key, string $value, array $options = NULL)
  * @method sadd
  * @method scan
  * @method scard
@@ -118,7 +118,11 @@ use InvalidArgumentException;
  * @method zremrangebylex
  * @method zremrangebyscore
  * @method zrevrangebylex
- * @method zrevrange
+ * @method array zrevrange(string $key, int $start, int $stop, array $options = NULL)
+ * @param string $key
+ * @param int $start
+ * @param int $stop
+ * @param array [$options]
  * @method zrevrangebyscore
  * @method zrevrank
  * @method zscan
@@ -304,7 +308,7 @@ class MemoryStorage
         }
 
         if (isset($this->COMMANDS[$command]['required'])) {
-            foreach($this->COMMANDS[$command]['required'] as $key) {
+            foreach ($this->COMMANDS[$command]['required'] as $key) {
                 $value = array_shift($arguments);
 
                 if ($value == null) {
@@ -368,11 +372,11 @@ class MemoryStorage
      * @param $key
      * @param $value
      */
-    private function assignParameter(&$data, $getter, $key, $value) {
+    private function assignParameter($data, $getter, $key, $value)
+    {
         if ($getter || $key == '_id') {
             $data[$key] = $value;
-        }
-        else {
+        } else {
             $data['body'][$key] = $value;
         }
     }
@@ -386,25 +390,20 @@ class MemoryStorage
      * @param $data
      * @param $options
      */
-    private function assignGeoRadiusOptions (&$data, &$options) {
+    private function assignGeoRadiusOptions($data, $options)
+    {
         $parsed = [];
 
-        $filtered = array_filter($options, function ($opt) {
-            return array_search($opt, ['withcoord', 'withdist', 'count', 'sort']);
-        });
-
-        foreach($options as $opt) {
-            if (array_search($opt, ['withcoord', 'withdist', 'count', 'sort'])) {
-                if ($opt == 'withcoord' || $opt == 'withdist') {
-                    array_push($parsed, $opt);
-                } else if ($opt == 'count' || $opt == 'sort') {
-                    if ($opt == 'count') {
-                        array_push($parsed, 'count');
-                    }
-
-                    array_push($parsed, $options[$opt]);
+        foreach ($options as $opt) {
+            if ($opt == 'withcoord' || $opt == 'withdist') {
+                array_push($parsed, $opt);
+                unset($options[$opt]);
+            } else if ($opt == 'count' || $opt == 'sort') {
+                if ($opt == 'count') {
+                    array_push($parsed, 'count');
                 }
 
+                array_push($parsed, $options[$opt]);
                 unset($options[$opt]);
             }
         }
@@ -422,8 +421,9 @@ class MemoryStorage
      * @param data
      * @param options
      */
-    private function assignZrangeOptions (&$data, &$options) {
-        &$data['options'] = ['withscores'];
+    private function assignZrangeOptions($data, $options)
+    {
+        $data['options'] = ['withscores'];
 
         if (isset($options['limit'])) {
             $data['limit'] = $options['limit'];
@@ -437,13 +437,14 @@ class MemoryStorage
      * @param results
      * @return array
      */
-    private function mapGeoposResults($results) {
+    private function mapGeoposResults($results)
+    {
         $ret = [];
 
-        foreach($results as $coords) {
+        foreach ($results as $coords) {
             $point = [];
 
-            foreach($coords as $latlon) {
+            foreach ($coords as $latlon) {
                 array_push($point, floatval($latlon));
             }
 
@@ -465,36 +466,129 @@ class MemoryStorage
      * @param results
      * @return array
      */
-    private function mapGeoRadiusResults($results) {
+    private function mapGeoRadiusResults($results)
+    {
+        $ret = [];
+
         // Simple array of point names (no options provided)
         if (!is_array($results[0])) {
-            return array_map(function (point) {
-                    return ['name' => point];
-            }, $results);
+            foreach ($results as $point) {
+                array_push($ret, ['name' => $point]);
+            }
+
+            return $ret;
         }
 
-        return results.map(function (point) {
-                // The point id is always the first item
-                var
-                p = {
-                    name: point[0]
-      },
-      i;
+        foreach ($results as $point) {
+            // The point id is always the first item
+            $p = ['name' => $point[0]];
+            $pointLength = count($point);
 
-    for (i = 1; i < point.length; i++) {
-        // withcoord result are in an array...
-        if (Array.isArray(point[i])) {
-            p.coordinates = point[i].map(function (coord) {
-                    return parseFloat(coord);
-                });
+            for ($i = 1; $i < $pointLength; $i++) {
+                // withcoord results are stored in an array...
+                if (is_array($point[$i])) {
+                    $p['coordinates'] = [];
+
+                    foreach ($point[$i] as $coord) {
+                        array_push($p['coordinates'], floatval($coord));
+                    }
+                } else {
+                    // ... while withdist ones are not
+                    $p['distance'] = floatval($point[$i]);
+                }
+
+                array_push($ret, $p);
+            }
         }
-        else {
-            // ... and withdist are not
-            p.distance = parseFloat(point[i]);
-        }
+
+        return $ret;
     }
 
-    return p;
-  });
+    /**
+     * Map a string result to an array of strings.
+     * Used to uniformize polymorphic results from redis
+     *
+     * @param results
+     * @return array
+     */
+    private function mapStringToArray($results)
+    {
+        return is_array($results) ? $results : array($results);
+    }
+
+    /**
+     * Map an array of strings to an array of integers
+     *
+     * @param results
+     * @return array
+     */
+    private function mapArrayStringToArrayInt($results)
+    {
+        $ret = [];
+
+        foreach ($results as $value) {
+            array_push($ret, intval($value));
+        }
+
+        return $ret;
+    }
+
+    /**
+     * Map results like ['key', 'value', 'key', 'value', ...]
+     * to a JSON object ['key' => 'value', 'key' => 'value', ...]
+     *
+     * @param results
+     * @return array
+     */
+    private function mapKeyValueResults($results)
+    {
+        $buffer = null;
+        $mapped = [];
+
+        foreach ($results as $value) {
+            if ($buffer === null) {
+                $buffer = $value;
+            } else {
+                $mapped[$buffer] = $value;
+                $buffer = null;
+            }
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * Map zrange results with WITHSCORES:
+     * [
+     *  "member1",
+     *  "score of member1",
+     *  "member2",
+     *  "score of member2"
+     * ]
+     *
+     * into the following format:
+     * [
+     *  {"member": "member1", "score": <score of member1>},
+     *  {"member": "member2", "score": <score of member2>},
+     * ]
+     *
+     *
+     * @param results
+     * @return array
+     */
+    private function mapZrangeResults($results)
+    {
+        $buffer = null;
+        $mapped = [];
+
+        foreach ($results as $value) {
+            if ($buffer === null) {
+                $buffer = $value;
+            } else {
+                array_push($mapped, ['member' => $buffer, 'score' => floatval($value)]);
+            }
+        }
+
+        return $mapped;
     }
 }

--- a/src/config/routes.json
+++ b/src/config/routes.json
@@ -357,7 +357,7 @@
     },
     "lindex": {
       "name": "lindex",
-      "route": "/ms/_lindex/:_id/:idx",
+      "route": "/ms/_lindex/:_id/:index",
       "method": "get"
     },
     "linsert": {
@@ -944,7 +944,7 @@
     },
     "lindex": {
       "name": "lindex",
-      "route": "/ms/_lindex/:_id/:idx",
+      "route": "/ms/_lindex/:_id/:index",
       "method": "get"
     },
     "linsert": {

--- a/src/config/routes.json
+++ b/src/config/routes.json
@@ -235,65 +235,25 @@
       "route": "/ms/_append/:_id",
       "method": "post"
     },
-    "asking": {
-      "name": "asking"
-    },
-    "auth": {
-      "name": "auth"
-    },
-    "bgrewriteaof": {
-      "name": "bgrewriteaof",
-      "route": "/ms/_bgrewriteaof",
-      "method": "post"
-    },
-    "bgsave": {
-      "name": "bgsave",
-      "route": "/ms/_bgsave",
-      "method": "post"
-    },
     "bitcount": {
-      "name": "bitcount"
-    },
-    "bitfield": {
-      "name": "bitfield"
+      "name": "bitcount",
+      "route": "/ms/_bitcount/:_id",
+      "method": "get"
     },
     "bitop": {
       "name": "bitop",
-      "route": "/ms/_bitop/:operation/:destkey",
+      "route": "/ms/_bitop/:_id",
       "method": "post"
     },
     "bitpos": {
       "name": "bitpos",
-      "route": "/ms/_bitpos/:_id/:bit",
+      "route": "/ms/_bitpos/:_id",
       "method": "get"
-    },
-    "blpop": {
-      "name": "blpop",
-      "route": "/ms/_blpop/:_id",
-      "method": "post"
-    },
-    "brpop": {
-      "name": "brpop",
-      "route": "/ms/_brpop/:_id",
-      "method": "post"
-    },
-    "brpoplpush": {
-      "name": "brpoplpush",
-      "route": "/ms/_brpoplpush",
-      "method": "post"
-    },
-    "command": {
-      "name": "command"
     },
     "dbsize": {
       "name": "dbsize",
       "route": "/ms/_dbsize",
       "method": "get"
-    },
-    "decr": {
-      "name": "decr",
-      "route": "/ms/_decr/:_id",
-      "method": "post"
     },
     "decrby": {
       "name": "decrby",
@@ -304,26 +264,6 @@
       "name": "del",
       "route": "/ms",
       "method": "delete"
-    },
-    "discard": {
-      "name": "discard",
-      "route": "/ms/_discard",
-      "method": "post"
-    },
-    "dump": {
-      "name": "dump",
-      "route": "/ms/_dump/:_id",
-      "method": "get"
-    },
-    "exec": {
-      "name": "exec",
-      "route": "/ms/_exec",
-      "method": "post"
-    },
-    "exists": {
-      "name": "exists",
-      "route": "/ms/_exists/:_id",
-      "method": "get"
     },
     "expire": {
       "name": "expire",
@@ -352,12 +292,7 @@
     },
     "geohash": {
       "name": "geohash",
-      "route": "/ms/_geohash/:_id/:member",
-      "method": "get"
-    },
-    "geopos": {
-      "name": "geopos",
-      "route": "/ms/_geopos/:_id/:member",
+      "route": "/ms/_geohash/:_id",
       "method": "get"
     },
     "georadius": {
@@ -370,42 +305,29 @@
       "route": "/ms/_georadiusbymember/:_id",
       "method": "get"
     },
-    "get": {
-      "name": "get",
-      "route": "/ms/:_id",
-      "method": "get"
-    },
     "getbit": {
       "name": "getbit",
-      "route": "/ms/_getbit/:_id/:offset",
+      "route": "/ms/_getbit/:_id",
       "method": "get"
     },
     "getrange": {
       "name": "getrange",
-      "route": "/ms/_getrange/:_id/:start/:end",
+      "route": "/ms/_getrange/:_id",
       "method": "get"
-    },
-    "getset": {
-      "name": "getset",
-      "route": "/ms/_getset/:_id",
-      "method": "post"
     },
     "hdel": {
       "name": "hdel",
       "route": "/ms/_hdel/:_id",
       "method": "delete"
     },
-    "hexists": {
-      "name": "hexists"
-    },
-    "hget": {
-      "name": "hget",
-      "route": "/ms/_hget/:_id/:field",
+    "hmget": {
+      "name": "hmget",
+      "route": "/ms/_hmget/:_id",
       "method": "get"
     },
-    "hgetall": {
-      "name": "hgetall",
-      "route": "/ms/_hgetall/:_id",
+    "hexists": {
+      "name": "hexists",
+      "route": "/ms/_hexists/:_id/:field",
       "method": "get"
     },
     "hincrby": {
@@ -413,42 +335,14 @@
       "route": "/ms/_hincrby/:_id",
       "method": "post"
     },
-    "hincrbyfloat": {
-      "name": "hincrbyfloat",
-      "route": "/ms/_hincrbyfloat/:_id",
-      "method": "post"
-    },
-    "hkeys": {
-      "name": "hkeys",
-      "route": "/ms/_hkeys/:_id",
-      "method": "get"
-    },
-    "hlen": {
-      "name": "hlen",
-      "route": "/ms/_hlen/:_id",
-      "method": "get"
-    },
-    "hmget": {
-      "name": "hmget",
-      "route": "/ms/_hmget/:_id/:field",
-      "method": "get"
-    },
     "hmset": {
       "name": "hmset",
       "route": "/ms/_hmset/:_id",
       "method": "post"
     },
-    "host:": {
-      "name": "host:"
-    },
     "hset": {
       "name": "hset",
       "route": "/ms/_hset/:_id",
-      "method": "post"
-    },
-    "hsetnx": {
-      "name": "hsetnx",
-      "route": "/ms/_hsetnx/:_id",
       "method": "post"
     },
     "hstrlen": {
@@ -456,43 +350,10 @@
       "route": "/ms/_hstrlen/:_id/:field",
       "method": "get"
     },
-    "hvals": {
-      "name": "hvals",
-      "route": "/ms/_hvals/:_id",
-      "method": "get"
-    },
-    "incr": {
-      "name": "incr",
-      "route": "/ms/_incr/:_id",
-      "method": "post"
-    },
-    "incrby": {
-      "name": "incrby",
-      "route": "/ms/_incrby/:_id",
-      "method": "post"
-    },
-    "incrbyfloat": {
-      "name": "incrbyfloat",
-      "route": "/ms/_incrbyfloat/:_id",
-      "method": "post"
-    },
-    "info": {
-      "name": "info",
-      "route": "/ms/_info",
-      "method": "get"
-    },
     "keys": {
       "name": "keys",
       "route": "/ms/_keys/:pattern",
       "method": "get"
-    },
-    "lastsave": {
-      "name": "lastsave",
-      "route": "/ms/_lastsave",
-      "method": "get"
-    },
-    "latency": {
-      "name": "latency"
     },
     "lindex": {
       "name": "lindex",
@@ -504,29 +365,14 @@
       "route": "/ms/_linsert/:_id",
       "method": "post"
     },
-    "llen": {
-      "name": "llen",
-      "route": "/ms/_llen/:_id",
-      "method": "get"
-    },
-    "lpop": {
-      "name": "lpop",
-      "route": "/ms/_lpop/:_id",
-      "method": "post"
-    },
     "lpush": {
       "name": "lpush",
       "route": "/ms/_lpush/:_id",
       "method": "post"
     },
-    "lpushx": {
-      "name": "lpushx",
-      "route": "/ms/_lpushx/:_id",
-      "method": "post"
-    },
     "lrange": {
       "name": "lrange",
-      "route": "/ms/_lrange/:_id/:start/:stop",
+      "route": "/ms/_lrange/:_id",
       "method": "get"
     },
     "lrem": {
@@ -544,41 +390,20 @@
       "route": "/ms/_ltrim/:_id",
       "method": "post"
     },
-    "memory": {
-      "name": "memory"
-    },
     "mget": {
       "name": "mget",
       "route": "/ms/_mget",
       "method": "get"
-    },
-    "module": {
-      "name": "module"
     },
     "mset": {
       "name": "mset",
       "route": "/ms/_mset",
       "method": "post"
     },
-    "msetnx": {
-      "name": "msetnx",
-      "route": "/ms/_msetnx",
-      "method": "post"
-    },
-    "multi": {
-      "name": "multi",
-      "route": "/ms/_multi",
-      "method": "post"
-    },
     "object": {
       "name": "object",
-      "route": "/ms/_object",
+      "route": "/ms/_object/:_id",
       "method": "get"
-    },
-    "persist": {
-      "name": "persist",
-      "route": "/ms/_persist/:_id",
-      "method": "post"
     },
     "pexpire": {
       "name": "pexpire",
@@ -595,46 +420,19 @@
       "route": "/ms/_pfadd/:_id",
       "method": "post"
     },
-    "pfcount": {
-      "name": "pfcount",
-      "route": "/ms/_pfcount",
-      "method": "get"
-    },
-    "pfdebug": {
-      "name": "pfdebug"
-    },
     "pfmerge": {
       "name": "pfmerge",
-      "route": "/ms/_pfmerge",
+      "route": "/ms/_pfmerge/:_id",
       "method": "post"
-    },
-    "pfselftest": {
-      "name": "pfselftest"
     },
     "ping": {
       "name": "ping",
       "route": "/ms/_ping",
       "method": "get"
     },
-    "post": {
-      "name": "post"
-    },
     "psetex": {
       "name": "psetex",
-      "route": "/ms/_psetex",
-      "method": "post"
-    },
-    "psync": {
-      "name": "psync"
-    },
-    "pttl": {
-      "name": "pttl",
-      "route": "/ms/_pttl/:_id",
-      "method": "get"
-    },
-    "publish": {
-      "name": "publish",
-      "route": "/ms/_publish/:channel",
+      "route": "/ms/_psetex/:_id",
       "method": "post"
     },
     "randomkey": {
@@ -652,35 +450,9 @@
       "route": "/ms/_renamenx/:_id",
       "method": "post"
     },
-    "replconf": {
-      "name": "replconf"
-    },
-    "restore": {
-      "name": "restore",
-      "route": "/ms/_restore/:_id",
-      "method": "post"
-    },
-    "restore-asking": {
-      "name": "restore-asking"
-    },
-    "rpop": {
-      "name": "rpop",
-      "route": "/ms/_rpop/:_id",
-      "method": "post"
-    },
     "rpoplpush": {
       "name": "rpoplpush",
       "route": "/ms/_rpoplpush",
-      "method": "post"
-    },
-    "rpush": {
-      "name": "rpush",
-      "route": "/ms/_rpush/:_id",
-      "method": "post"
-    },
-    "rpushx": {
-      "name": "rpushx",
-      "route": "/ms/_rpushx/:_id",
       "method": "post"
     },
     "sadd": {
@@ -688,14 +460,9 @@
       "route": "/ms/_sadd/:_id",
       "method": "post"
     },
-    "save": {
-      "name": "save",
-      "route": "/ms/_save",
-      "method": "post"
-    },
-    "scard": {
-      "name": "scard",
-      "route": "/ms/_scard/:_id",
+    "scan": {
+      "name": "scan",
+      "route": "/ms/_scan",
       "method": "get"
     },
     "sdiff": {
@@ -705,17 +472,12 @@
     },
     "sdiffstore": {
       "name": "sdiffstore",
-      "route": "/ms/_sdiffstore",
+      "route": "/ms/_sdiffstore/:_id",
       "method": "post"
     },
     "set": {
       "name": "set",
-      "route": "/ms/:_id",
-      "method": "post"
-    },
-    "setbit": {
-      "name": "setbit",
-      "route": "/ms/_setbit/:_id",
+      "route": "/ms/_set/:_id",
       "method": "post"
     },
     "setex": {
@@ -728,19 +490,9 @@
       "route": "/ms/_setnx/:_id",
       "method": "post"
     },
-    "setrange": {
-      "name": "setrange",
-      "route": "/ms/_setrange/:_id",
-      "method": "post"
-    },
-    "sinter": {
-      "name": "sinter",
-      "route": "/ms/_sinter/:_id",
-      "method": "get"
-    },
     "sinterstore": {
       "name": "sinterstore",
-      "route": "/ms/_sinterstore/:_id",
+      "route": "/ms/_sinterstore",
       "method": "post"
     },
     "sismember": {
@@ -748,14 +500,9 @@
       "route": "/ms/_sismember/:_id/:member",
       "method": "get"
     },
-    "smembers": {
-      "name": "smembers",
-      "route": "/ms/_smembers/:_id",
-      "method": "get"
-    },
     "smove": {
       "name": "smove",
-      "route": "/ms/_smove",
+      "route": "/ms/_smove/:_id",
       "method": "post"
     },
     "sort": {
@@ -778,26 +525,20 @@
       "route": "/ms/_srem/:_id",
       "method": "delete"
     },
-    "strlen": {
-      "name": "strlen",
-      "route": "/ms/_strlen/:_id",
+    "sscan": {
+      "name": "sscan",
+      "route": "/ms/_sscan/:_id",
       "method": "get"
-    },
-    "substr": {
-      "name": "substr"
     },
     "sunion": {
       "name": "sunion",
-      "route": "/ms/_sunion/:_id",
-      "method": "post"
+      "route": "/ms/_sunion",
+      "method": "get"
     },
     "sunionstore": {
       "name": "sunionstore",
-      "route": "/ms/_sunionstore/:_id",
+      "route": "/ms/_sunionstore",
       "method": "post"
-    },
-    "swapdb": {
-      "name": "swapdb"
     },
     "time": {
       "name": "time",
@@ -805,43 +546,18 @@
       "method": "get"
     },
     "touch": {
-      "name": "touch"
-    },
-    "ttl": {
-      "name": "ttl",
-      "route": "/ms/_ttl/:_id",
-      "method": "get"
-    },
-    "type": {
-      "name": "type",
-      "route": "/ms/_type/:_id",
-      "method": "get"
-    },
-    "unlink": {
-      "name": "unlink"
-    },
-    "unwatch": {
-      "name": "unwatch"
-    },
-    "wait": {
-      "name": "wait"
-    },
-    "watch": {
-      "name": "watch"
+      "name": "touch",
+      "route": "/ms/_touch",
+      "method": "post"
     },
     "zadd": {
       "name": "zadd",
       "route": "/ms/_zadd/:_id",
       "method": "post"
     },
-    "zcard": {
-      "name": "zcard",
-      "route": "/ms/_zcard/:_id",
-      "method": "get"
-    },
     "zcount": {
       "name": "zcount",
-      "route": "/ms/_zcount/:_id/:min/:max",
+      "route": "/ms/_zcount/:_id",
       "method": "get"
     },
     "zincrby": {
@@ -851,32 +567,27 @@
     },
     "zinterstore": {
       "name": "zinterstore",
-      "route": "/ms/_zinterstore",
+      "route": "/ms/_zinterstore/:_id",
       "method": "post"
     },
     "zlexcount": {
       "name": "zlexcount",
-      "route": "/ms/_zlexcount/:_id/:min/:max",
+      "route": "/ms/_zlexcount/:_id",
       "method": "get"
     },
     "zrange": {
       "name": "zrange",
-      "route": "/ms/_zrange/:_id/:start/:stop",
+      "route": "/ms/_zrange/:_id",
       "method": "get"
     },
     "zrangebylex": {
       "name": "zrangebylex",
-      "route": "/ms/_zrangebylex/:_id/:min/:max",
+      "route": "/ms/_zrangebylex/:_id",
       "method": "get"
     },
     "zrangebyscore": {
       "name": "zrangebyscore",
-      "route": "/ms/_zrangebyscore/:_id/:min/:max",
-      "method": "get"
-    },
-    "zrank": {
-      "name": "zrank",
-      "route": "/ms/_zrank/:_id/:member",
+      "route": "/ms/_zrangebyscore/:_id",
       "method": "get"
     },
     "zrem": {
@@ -890,26 +601,23 @@
       "method": "delete"
     },
     "zremrangebyrank": {
-      "name": "zremrangebyrank"
+      "name": "zremrangebyrank",
+      "route": "/ms/_zremrangebyrank/:_id",
+      "method": "delete"
     },
     "zremrangebyscore": {
       "name": "zremrangebyscore",
       "route": "/ms/_zremrangebyscore/:_id",
       "method": "delete"
     },
-    "zrevrange": {
-      "name": "zrevrange",
-      "route": "/ms/_zrevrange/:_id/:start/:stop",
-      "method": "get"
-    },
     "zrevrangebylex": {
       "name": "zrevrangebylex",
-      "route": "/ms/_zrevrangebylex/:_id/:min/:max",
+      "route": "/ms/_zrevrangebylex/:_id",
       "method": "get"
     },
     "zrevrangebyscore": {
       "name": "zrevrangebyscore",
-      "route": "/ms/_zrevrangebyscore/:_id/:max/:min",
+      "route": "/ms/_zrevrangebyscore/:_id",
       "method": "get"
     },
     "zrevrank": {
@@ -917,18 +625,195 @@
       "route": "/ms/_zrevrank/:_id/:member",
       "method": "get"
     },
+    "zunionstore": {
+      "name": "zunionstore",
+      "route": "/ms/_zunionstore/:_id",
+      "method": "post"
+    },
+    "zcard": {
+      "name": "zcard",
+      "route": "/ms/_zcard/:_id",
+      "method": "get"
+    },
+    "type": {
+      "name": "type",
+      "route": "/ms/_type/:_id",
+      "method": "get"
+    },
+    "ttl": {
+      "name": "ttl",
+      "route": "/ms/_ttl/:_id",
+      "method": "get"
+    },
+    "strlen": {
+      "name": "strlen",
+      "route": "/ms/_strlen/:_id",
+      "method": "get"
+    },
+    "smembers": {
+      "name": "smembers",
+      "route": "/ms/_smembers/:_id",
+      "method": "get"
+    },
+    "scard": {
+      "name": "scard",
+      "route": "/ms/_scard/:_id",
+      "method": "get"
+    },
+    "rpop": {
+      "name": "rpop",
+      "route": "/ms/_rpop/:_id",
+      "method": "post"
+    },
+    "pttl": {
+      "name": "pttl",
+      "route": "/ms/_pttl/:_id",
+      "method": "get"
+    },
+    "persist": {
+      "name": "persist",
+      "route": "/ms/_persist/:_id",
+      "method": "post"
+    },
+    "lpop": {
+      "name": "lpop",
+      "route": "/ms/_lpop/:_id",
+      "method": "post"
+    },
+    "llen": {
+      "name": "llen",
+      "route": "/ms/_llen/:_id",
+      "method": "get"
+    },
+    "incr": {
+      "name": "incr",
+      "route": "/ms/_incr/:_id",
+      "method": "post"
+    },
+    "hvals": {
+      "name": "hvals",
+      "route": "/ms/_hvals/:_id",
+      "method": "get"
+    },
+    "hlen": {
+      "name": "hlen",
+      "route": "/ms/_hlen/:_id",
+      "method": "get"
+    },
+    "hkeys": {
+      "name": "hkeys",
+      "route": "/ms/_hkeys/:_id",
+      "method": "get"
+    },
+    "hgetall": {
+      "name": "hgetall",
+      "route": "/ms/_hgetall/:_id",
+      "method": "get"
+    },
+    "get": {
+      "name": "get",
+      "route": "/ms/:_id",
+      "method": "get"
+    },
+    "decr": {
+      "name": "decr",
+      "route": "/ms/_decr/:_id",
+      "method": "post"
+    },
+    "rpushx": {
+      "name": "rpushx",
+      "route": "/ms/_rpushx/:_id",
+      "method": "post"
+    },
+    "lpushx": {
+      "name": "lpushx",
+      "route": "/ms/_lpushx/:_id",
+      "method": "post"
+    },
+    "getset": {
+      "name": "getset",
+      "route": "/ms/_getset/:_id",
+      "method": "post"
+    },
+    "sinter": {
+      "name": "sinter",
+      "route": "/ms/_sinter",
+      "method": "get"
+    },
+    "pfcount": {
+      "name": "pfcount",
+      "route": "/ms/_pfcount",
+      "method": "get"
+    },
+    "incrbyfloat": {
+      "name": "incrbyfloat",
+      "route": "/ms/_incrbyfloat/:_id",
+      "method": "post"
+    },
+    "incrby": {
+      "name": "incrby",
+      "route": "/ms/_incrby/:_id",
+      "method": "post"
+    },
+    "geopos": {
+      "name": "geopos",
+      "route": "/ms/_geopos/:_id",
+      "method": "get"
+    },
+    "hget": {
+      "name": "hget",
+      "route": "/ms/_hget/:_id/:field",
+      "method": "get"
+    },
+    "hsetnx": {
+      "name": "hsetnx",
+      "route": "/ms/_hsetnx/:_id",
+      "method": "post"
+    },
+    "msetnx": {
+      "name": "msetnx",
+      "route": "/ms/_msetnx",
+      "method": "post"
+    },
+    "rpush": {
+      "name": "rpush",
+      "route": "/ms/_rpush/:_id",
+      "method": "post"
+    },
+    "hincrbyfloat": {
+      "name": "hincrbyfloat",
+      "route": "/ms/_hincrbyfloat/:_id",
+      "method": "post"
+    },
+    "zrevrange": {
+      "name": "zrevrange",
+      "route": "/ms/_zrevrange/:_id",
+      "method": "get"
+    },
+    "zrank": {
+      "name": "zrank",
+      "route": "/ms/_zrank/:_id/:member",
+      "method": "get"
+    },
     "zscore": {
       "name": "zscore",
       "route": "/ms/_zscore/:_id/:member",
       "method": "get"
     },
-    "zunionstore": {
-      "name": "zunionstore",
-      "route": "/ms/_zunionstore",
-      "method": "post"
+    "zscan": {
+      "name": "zscan",
+      "route": "/ms/_zscan/:_id",
+      "method": "get"
     },
-    "sentinel": {
-      "name": "sentinel"
+    "hscan": {
+      "name": "hscan",
+      "route": "/ms/_hscan/:_id",
+      "method": "get"
+    },
+    "exists": {
+      "name": "exists",
+      "route": "/ms/_exists",
+      "method": "get"
     }
   },
   "memoryStorage": {
@@ -937,65 +822,25 @@
       "route": "/ms/_append/:_id",
       "method": "post"
     },
-    "asking": {
-      "name": "asking"
-    },
-    "auth": {
-      "name": "auth"
-    },
-    "bgrewriteaof": {
-      "name": "bgrewriteaof",
-      "route": "/ms/_bgrewriteaof",
-      "method": "post"
-    },
-    "bgsave": {
-      "name": "bgsave",
-      "route": "/ms/_bgsave",
-      "method": "post"
-    },
     "bitcount": {
-      "name": "bitcount"
-    },
-    "bitfield": {
-      "name": "bitfield"
+      "name": "bitcount",
+      "route": "/ms/_bitcount/:_id",
+      "method": "get"
     },
     "bitop": {
       "name": "bitop",
-      "route": "/ms/_bitop/:operation/:destkey",
+      "route": "/ms/_bitop/:_id",
       "method": "post"
     },
     "bitpos": {
       "name": "bitpos",
-      "route": "/ms/_bitpos/:_id/:bit",
+      "route": "/ms/_bitpos/:_id",
       "method": "get"
-    },
-    "blpop": {
-      "name": "blpop",
-      "route": "/ms/_blpop/:_id",
-      "method": "post"
-    },
-    "brpop": {
-      "name": "brpop",
-      "route": "/ms/_brpop/:_id",
-      "method": "post"
-    },
-    "brpoplpush": {
-      "name": "brpoplpush",
-      "route": "/ms/_brpoplpush",
-      "method": "post"
-    },
-    "command": {
-      "name": "command"
     },
     "dbsize": {
       "name": "dbsize",
       "route": "/ms/_dbsize",
       "method": "get"
-    },
-    "decr": {
-      "name": "decr",
-      "route": "/ms/_decr/:_id",
-      "method": "post"
     },
     "decrby": {
       "name": "decrby",
@@ -1006,26 +851,6 @@
       "name": "del",
       "route": "/ms",
       "method": "delete"
-    },
-    "discard": {
-      "name": "discard",
-      "route": "/ms/_discard",
-      "method": "post"
-    },
-    "dump": {
-      "name": "dump",
-      "route": "/ms/_dump/:_id",
-      "method": "get"
-    },
-    "exec": {
-      "name": "exec",
-      "route": "/ms/_exec",
-      "method": "post"
-    },
-    "exists": {
-      "name": "exists",
-      "route": "/ms/_exists/:_id",
-      "method": "get"
     },
     "expire": {
       "name": "expire",
@@ -1054,12 +879,7 @@
     },
     "geohash": {
       "name": "geohash",
-      "route": "/ms/_geohash/:_id/:member",
-      "method": "get"
-    },
-    "geopos": {
-      "name": "geopos",
-      "route": "/ms/_geopos/:_id/:member",
+      "route": "/ms/_geohash/:_id",
       "method": "get"
     },
     "georadius": {
@@ -1072,42 +892,29 @@
       "route": "/ms/_georadiusbymember/:_id",
       "method": "get"
     },
-    "get": {
-      "name": "get",
-      "route": "/ms/:_id",
-      "method": "get"
-    },
     "getbit": {
       "name": "getbit",
-      "route": "/ms/_getbit/:_id/:offset",
+      "route": "/ms/_getbit/:_id",
       "method": "get"
     },
     "getrange": {
       "name": "getrange",
-      "route": "/ms/_getrange/:_id/:start/:end",
+      "route": "/ms/_getrange/:_id",
       "method": "get"
-    },
-    "getset": {
-      "name": "getset",
-      "route": "/ms/_getset/:_id",
-      "method": "post"
     },
     "hdel": {
       "name": "hdel",
       "route": "/ms/_hdel/:_id",
       "method": "delete"
     },
-    "hexists": {
-      "name": "hexists"
-    },
-    "hget": {
-      "name": "hget",
-      "route": "/ms/_hget/:_id/:field",
+    "hmget": {
+      "name": "hmget",
+      "route": "/ms/_hmget/:_id",
       "method": "get"
     },
-    "hgetall": {
-      "name": "hgetall",
-      "route": "/ms/_hgetall/:_id",
+    "hexists": {
+      "name": "hexists",
+      "route": "/ms/_hexists/:_id/:field",
       "method": "get"
     },
     "hincrby": {
@@ -1115,42 +922,14 @@
       "route": "/ms/_hincrby/:_id",
       "method": "post"
     },
-    "hincrbyfloat": {
-      "name": "hincrbyfloat",
-      "route": "/ms/_hincrbyfloat/:_id",
-      "method": "post"
-    },
-    "hkeys": {
-      "name": "hkeys",
-      "route": "/ms/_hkeys/:_id",
-      "method": "get"
-    },
-    "hlen": {
-      "name": "hlen",
-      "route": "/ms/_hlen/:_id",
-      "method": "get"
-    },
-    "hmget": {
-      "name": "hmget",
-      "route": "/ms/_hmget/:_id/:field",
-      "method": "get"
-    },
     "hmset": {
       "name": "hmset",
       "route": "/ms/_hmset/:_id",
       "method": "post"
     },
-    "host:": {
-      "name": "host:"
-    },
     "hset": {
       "name": "hset",
       "route": "/ms/_hset/:_id",
-      "method": "post"
-    },
-    "hsetnx": {
-      "name": "hsetnx",
-      "route": "/ms/_hsetnx/:_id",
       "method": "post"
     },
     "hstrlen": {
@@ -1158,43 +937,10 @@
       "route": "/ms/_hstrlen/:_id/:field",
       "method": "get"
     },
-    "hvals": {
-      "name": "hvals",
-      "route": "/ms/_hvals/:_id",
-      "method": "get"
-    },
-    "incr": {
-      "name": "incr",
-      "route": "/ms/_incr/:_id",
-      "method": "post"
-    },
-    "incrby": {
-      "name": "incrby",
-      "route": "/ms/_incrby/:_id",
-      "method": "post"
-    },
-    "incrbyfloat": {
-      "name": "incrbyfloat",
-      "route": "/ms/_incrbyfloat/:_id",
-      "method": "post"
-    },
-    "info": {
-      "name": "info",
-      "route": "/ms/_info",
-      "method": "get"
-    },
     "keys": {
       "name": "keys",
       "route": "/ms/_keys/:pattern",
       "method": "get"
-    },
-    "lastsave": {
-      "name": "lastsave",
-      "route": "/ms/_lastsave",
-      "method": "get"
-    },
-    "latency": {
-      "name": "latency"
     },
     "lindex": {
       "name": "lindex",
@@ -1206,29 +952,14 @@
       "route": "/ms/_linsert/:_id",
       "method": "post"
     },
-    "llen": {
-      "name": "llen",
-      "route": "/ms/_llen/:_id",
-      "method": "get"
-    },
-    "lpop": {
-      "name": "lpop",
-      "route": "/ms/_lpop/:_id",
-      "method": "post"
-    },
     "lpush": {
       "name": "lpush",
       "route": "/ms/_lpush/:_id",
       "method": "post"
     },
-    "lpushx": {
-      "name": "lpushx",
-      "route": "/ms/_lpushx/:_id",
-      "method": "post"
-    },
     "lrange": {
       "name": "lrange",
-      "route": "/ms/_lrange/:_id/:start/:stop",
+      "route": "/ms/_lrange/:_id",
       "method": "get"
     },
     "lrem": {
@@ -1246,41 +977,20 @@
       "route": "/ms/_ltrim/:_id",
       "method": "post"
     },
-    "memory": {
-      "name": "memory"
-    },
     "mget": {
       "name": "mget",
       "route": "/ms/_mget",
       "method": "get"
-    },
-    "module": {
-      "name": "module"
     },
     "mset": {
       "name": "mset",
       "route": "/ms/_mset",
       "method": "post"
     },
-    "msetnx": {
-      "name": "msetnx",
-      "route": "/ms/_msetnx",
-      "method": "post"
-    },
-    "multi": {
-      "name": "multi",
-      "route": "/ms/_multi",
-      "method": "post"
-    },
     "object": {
       "name": "object",
-      "route": "/ms/_object",
+      "route": "/ms/_object/:_id",
       "method": "get"
-    },
-    "persist": {
-      "name": "persist",
-      "route": "/ms/_persist/:_id",
-      "method": "post"
     },
     "pexpire": {
       "name": "pexpire",
@@ -1297,46 +1007,19 @@
       "route": "/ms/_pfadd/:_id",
       "method": "post"
     },
-    "pfcount": {
-      "name": "pfcount",
-      "route": "/ms/_pfcount",
-      "method": "get"
-    },
-    "pfdebug": {
-      "name": "pfdebug"
-    },
     "pfmerge": {
       "name": "pfmerge",
-      "route": "/ms/_pfmerge",
+      "route": "/ms/_pfmerge/:_id",
       "method": "post"
-    },
-    "pfselftest": {
-      "name": "pfselftest"
     },
     "ping": {
       "name": "ping",
       "route": "/ms/_ping",
       "method": "get"
     },
-    "post": {
-      "name": "post"
-    },
     "psetex": {
       "name": "psetex",
-      "route": "/ms/_psetex",
-      "method": "post"
-    },
-    "psync": {
-      "name": "psync"
-    },
-    "pttl": {
-      "name": "pttl",
-      "route": "/ms/_pttl/:_id",
-      "method": "get"
-    },
-    "publish": {
-      "name": "publish",
-      "route": "/ms/_publish/:channel",
+      "route": "/ms/_psetex/:_id",
       "method": "post"
     },
     "randomkey": {
@@ -1354,35 +1037,9 @@
       "route": "/ms/_renamenx/:_id",
       "method": "post"
     },
-    "replconf": {
-      "name": "replconf"
-    },
-    "restore": {
-      "name": "restore",
-      "route": "/ms/_restore/:_id",
-      "method": "post"
-    },
-    "restore-asking": {
-      "name": "restore-asking"
-    },
-    "rpop": {
-      "name": "rpop",
-      "route": "/ms/_rpop/:_id",
-      "method": "post"
-    },
     "rpoplpush": {
       "name": "rpoplpush",
       "route": "/ms/_rpoplpush",
-      "method": "post"
-    },
-    "rpush": {
-      "name": "rpush",
-      "route": "/ms/_rpush/:_id",
-      "method": "post"
-    },
-    "rpushx": {
-      "name": "rpushx",
-      "route": "/ms/_rpushx/:_id",
       "method": "post"
     },
     "sadd": {
@@ -1390,14 +1047,9 @@
       "route": "/ms/_sadd/:_id",
       "method": "post"
     },
-    "save": {
-      "name": "save",
-      "route": "/ms/_save",
-      "method": "post"
-    },
-    "scard": {
-      "name": "scard",
-      "route": "/ms/_scard/:_id",
+    "scan": {
+      "name": "scan",
+      "route": "/ms/_scan",
       "method": "get"
     },
     "sdiff": {
@@ -1407,17 +1059,12 @@
     },
     "sdiffstore": {
       "name": "sdiffstore",
-      "route": "/ms/_sdiffstore",
+      "route": "/ms/_sdiffstore/:_id",
       "method": "post"
     },
     "set": {
       "name": "set",
-      "route": "/ms/:_id",
-      "method": "post"
-    },
-    "setbit": {
-      "name": "setbit",
-      "route": "/ms/_setbit/:_id",
+      "route": "/ms/_set/:_id",
       "method": "post"
     },
     "setex": {
@@ -1430,19 +1077,9 @@
       "route": "/ms/_setnx/:_id",
       "method": "post"
     },
-    "setrange": {
-      "name": "setrange",
-      "route": "/ms/_setrange/:_id",
-      "method": "post"
-    },
-    "sinter": {
-      "name": "sinter",
-      "route": "/ms/_sinter/:_id",
-      "method": "get"
-    },
     "sinterstore": {
       "name": "sinterstore",
-      "route": "/ms/_sinterstore/:_id",
+      "route": "/ms/_sinterstore",
       "method": "post"
     },
     "sismember": {
@@ -1450,14 +1087,9 @@
       "route": "/ms/_sismember/:_id/:member",
       "method": "get"
     },
-    "smembers": {
-      "name": "smembers",
-      "route": "/ms/_smembers/:_id",
-      "method": "get"
-    },
     "smove": {
       "name": "smove",
-      "route": "/ms/_smove",
+      "route": "/ms/_smove/:_id",
       "method": "post"
     },
     "sort": {
@@ -1480,26 +1112,20 @@
       "route": "/ms/_srem/:_id",
       "method": "delete"
     },
-    "strlen": {
-      "name": "strlen",
-      "route": "/ms/_strlen/:_id",
+    "sscan": {
+      "name": "sscan",
+      "route": "/ms/_sscan/:_id",
       "method": "get"
-    },
-    "substr": {
-      "name": "substr"
     },
     "sunion": {
       "name": "sunion",
-      "route": "/ms/_sunion/:_id",
-      "method": "post"
+      "route": "/ms/_sunion",
+      "method": "get"
     },
     "sunionstore": {
       "name": "sunionstore",
-      "route": "/ms/_sunionstore/:_id",
+      "route": "/ms/_sunionstore",
       "method": "post"
-    },
-    "swapdb": {
-      "name": "swapdb"
     },
     "time": {
       "name": "time",
@@ -1507,43 +1133,18 @@
       "method": "get"
     },
     "touch": {
-      "name": "touch"
-    },
-    "ttl": {
-      "name": "ttl",
-      "route": "/ms/_ttl/:_id",
-      "method": "get"
-    },
-    "type": {
-      "name": "type",
-      "route": "/ms/_type/:_id",
-      "method": "get"
-    },
-    "unlink": {
-      "name": "unlink"
-    },
-    "unwatch": {
-      "name": "unwatch"
-    },
-    "wait": {
-      "name": "wait"
-    },
-    "watch": {
-      "name": "watch"
+      "name": "touch",
+      "route": "/ms/_touch",
+      "method": "post"
     },
     "zadd": {
       "name": "zadd",
       "route": "/ms/_zadd/:_id",
       "method": "post"
     },
-    "zcard": {
-      "name": "zcard",
-      "route": "/ms/_zcard/:_id",
-      "method": "get"
-    },
     "zcount": {
       "name": "zcount",
-      "route": "/ms/_zcount/:_id/:min/:max",
+      "route": "/ms/_zcount/:_id",
       "method": "get"
     },
     "zincrby": {
@@ -1553,32 +1154,27 @@
     },
     "zinterstore": {
       "name": "zinterstore",
-      "route": "/ms/_zinterstore",
+      "route": "/ms/_zinterstore/:_id",
       "method": "post"
     },
     "zlexcount": {
       "name": "zlexcount",
-      "route": "/ms/_zlexcount/:_id/:min/:max",
+      "route": "/ms/_zlexcount/:_id",
       "method": "get"
     },
     "zrange": {
       "name": "zrange",
-      "route": "/ms/_zrange/:_id/:start/:stop",
+      "route": "/ms/_zrange/:_id",
       "method": "get"
     },
     "zrangebylex": {
       "name": "zrangebylex",
-      "route": "/ms/_zrangebylex/:_id/:min/:max",
+      "route": "/ms/_zrangebylex/:_id",
       "method": "get"
     },
     "zrangebyscore": {
       "name": "zrangebyscore",
-      "route": "/ms/_zrangebyscore/:_id/:min/:max",
-      "method": "get"
-    },
-    "zrank": {
-      "name": "zrank",
-      "route": "/ms/_zrank/:_id/:member",
+      "route": "/ms/_zrangebyscore/:_id",
       "method": "get"
     },
     "zrem": {
@@ -1592,26 +1188,23 @@
       "method": "delete"
     },
     "zremrangebyrank": {
-      "name": "zremrangebyrank"
+      "name": "zremrangebyrank",
+      "route": "/ms/_zremrangebyrank/:_id",
+      "method": "delete"
     },
     "zremrangebyscore": {
       "name": "zremrangebyscore",
       "route": "/ms/_zremrangebyscore/:_id",
       "method": "delete"
     },
-    "zrevrange": {
-      "name": "zrevrange",
-      "route": "/ms/_zrevrange/:_id/:start/:stop",
-      "method": "get"
-    },
     "zrevrangebylex": {
       "name": "zrevrangebylex",
-      "route": "/ms/_zrevrangebylex/:_id/:min/:max",
+      "route": "/ms/_zrevrangebylex/:_id",
       "method": "get"
     },
     "zrevrangebyscore": {
       "name": "zrevrangebyscore",
-      "route": "/ms/_zrevrangebyscore/:_id/:max/:min",
+      "route": "/ms/_zrevrangebyscore/:_id",
       "method": "get"
     },
     "zrevrank": {
@@ -1619,18 +1212,195 @@
       "route": "/ms/_zrevrank/:_id/:member",
       "method": "get"
     },
+    "zunionstore": {
+      "name": "zunionstore",
+      "route": "/ms/_zunionstore/:_id",
+      "method": "post"
+    },
+    "zcard": {
+      "name": "zcard",
+      "route": "/ms/_zcard/:_id",
+      "method": "get"
+    },
+    "type": {
+      "name": "type",
+      "route": "/ms/_type/:_id",
+      "method": "get"
+    },
+    "ttl": {
+      "name": "ttl",
+      "route": "/ms/_ttl/:_id",
+      "method": "get"
+    },
+    "strlen": {
+      "name": "strlen",
+      "route": "/ms/_strlen/:_id",
+      "method": "get"
+    },
+    "smembers": {
+      "name": "smembers",
+      "route": "/ms/_smembers/:_id",
+      "method": "get"
+    },
+    "scard": {
+      "name": "scard",
+      "route": "/ms/_scard/:_id",
+      "method": "get"
+    },
+    "rpop": {
+      "name": "rpop",
+      "route": "/ms/_rpop/:_id",
+      "method": "post"
+    },
+    "pttl": {
+      "name": "pttl",
+      "route": "/ms/_pttl/:_id",
+      "method": "get"
+    },
+    "persist": {
+      "name": "persist",
+      "route": "/ms/_persist/:_id",
+      "method": "post"
+    },
+    "lpop": {
+      "name": "lpop",
+      "route": "/ms/_lpop/:_id",
+      "method": "post"
+    },
+    "llen": {
+      "name": "llen",
+      "route": "/ms/_llen/:_id",
+      "method": "get"
+    },
+    "incr": {
+      "name": "incr",
+      "route": "/ms/_incr/:_id",
+      "method": "post"
+    },
+    "hvals": {
+      "name": "hvals",
+      "route": "/ms/_hvals/:_id",
+      "method": "get"
+    },
+    "hlen": {
+      "name": "hlen",
+      "route": "/ms/_hlen/:_id",
+      "method": "get"
+    },
+    "hkeys": {
+      "name": "hkeys",
+      "route": "/ms/_hkeys/:_id",
+      "method": "get"
+    },
+    "hgetall": {
+      "name": "hgetall",
+      "route": "/ms/_hgetall/:_id",
+      "method": "get"
+    },
+    "get": {
+      "name": "get",
+      "route": "/ms/:_id",
+      "method": "get"
+    },
+    "decr": {
+      "name": "decr",
+      "route": "/ms/_decr/:_id",
+      "method": "post"
+    },
+    "rpushx": {
+      "name": "rpushx",
+      "route": "/ms/_rpushx/:_id",
+      "method": "post"
+    },
+    "lpushx": {
+      "name": "lpushx",
+      "route": "/ms/_lpushx/:_id",
+      "method": "post"
+    },
+    "getset": {
+      "name": "getset",
+      "route": "/ms/_getset/:_id",
+      "method": "post"
+    },
+    "sinter": {
+      "name": "sinter",
+      "route": "/ms/_sinter",
+      "method": "get"
+    },
+    "pfcount": {
+      "name": "pfcount",
+      "route": "/ms/_pfcount",
+      "method": "get"
+    },
+    "incrbyfloat": {
+      "name": "incrbyfloat",
+      "route": "/ms/_incrbyfloat/:_id",
+      "method": "post"
+    },
+    "incrby": {
+      "name": "incrby",
+      "route": "/ms/_incrby/:_id",
+      "method": "post"
+    },
+    "geopos": {
+      "name": "geopos",
+      "route": "/ms/_geopos/:_id",
+      "method": "get"
+    },
+    "hget": {
+      "name": "hget",
+      "route": "/ms/_hget/:_id/:field",
+      "method": "get"
+    },
+    "hsetnx": {
+      "name": "hsetnx",
+      "route": "/ms/_hsetnx/:_id",
+      "method": "post"
+    },
+    "msetnx": {
+      "name": "msetnx",
+      "route": "/ms/_msetnx",
+      "method": "post"
+    },
+    "rpush": {
+      "name": "rpush",
+      "route": "/ms/_rpush/:_id",
+      "method": "post"
+    },
+    "hincrbyfloat": {
+      "name": "hincrbyfloat",
+      "route": "/ms/_hincrbyfloat/:_id",
+      "method": "post"
+    },
+    "zrevrange": {
+      "name": "zrevrange",
+      "route": "/ms/_zrevrange/:_id",
+      "method": "get"
+    },
+    "zrank": {
+      "name": "zrank",
+      "route": "/ms/_zrank/:_id/:member",
+      "method": "get"
+    },
     "zscore": {
       "name": "zscore",
       "route": "/ms/_zscore/:_id/:member",
       "method": "get"
     },
-    "zunionstore": {
-      "name": "zunionstore",
-      "route": "/ms/_zunionstore",
-      "method": "post"
+    "zscan": {
+      "name": "zscan",
+      "route": "/ms/_zscan/:_id",
+      "method": "get"
     },
-    "sentinel": {
-      "name": "sentinel"
+    "hscan": {
+      "name": "hscan",
+      "route": "/ms/_hscan/:_id",
+      "method": "get"
+    },
+    "exists": {
+      "name": "exists",
+      "route": "/ms/_exists",
+      "method": "get"
     }
   },
   "realtime": {

--- a/tests/MemoryStorageTest.php
+++ b/tests/MemoryStorageTest.php
@@ -107,10 +107,14 @@ class MemoryStorageTest extends TestCase
     }
 
     public function testAppend() {
-        $this->SetupMemoryStorageCommand('append', 'POST', '/ms/_append/key', [
-           '_id' => 'key',
-            'body' => ['value' => 'foo']
-        ], [], 3);
+        $this->SetupMemoryStorageCommand(
+            'append',
+            'POST',
+            '/ms/_append/key',
+            ['_id' => 'key', 'body' => ['value' => 'foo']],
+            [],
+            3
+        );
 
         $result = $this->memoryStorage->append('key', 'foo', $this->options);
         $this->assertEquals($result, 3);
@@ -573,9 +577,12 @@ class MemoryStorageTest extends TestCase
             'GET',
             '/ms/_hscan/key',
             ['_id' => 'key'],
-            ['cursor' => 0],
+            ['cursor' => 0, 'count' => 10, 'match' => 'foo*'],
             [18, ['foo', 'bar', 'baz', 'qux']]
         );
+
+        $this->options['count'] = 10;
+        $this->options['match'] = 'foo*';
 
         $result = $this->memoryStorage->hscan('key', 0, $this->options);
         $this->assertEquals($result, [18, ['foo', 'bar', 'baz', 'qux']]);
@@ -942,6 +949,677 @@ class MemoryStorageTest extends TestCase
         $this->assertEquals($result, 1);
     }
 
+    public function testPfadd() {
+        $this->SetupMemoryStorageCommand(
+            'pfadd',
+            'POST',
+            '/ms/_pfadd/key',
+            ['_id' => 'key', 'body' => ['elements' => ['foo', 'bar', 'baz']]],
+            [],
+            1
+        );
+
+        $result = $this->memoryStorage->pfadd('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testPfcount() {
+        $this->SetupMemoryStorageCommand(
+            'pfcount',
+            'GET',
+            '/ms/_pfcount',
+            [],
+            ['keys' => 'foo,bar,baz'],
+            5
+        );
+
+        $result = $this->memoryStorage->pfcount(['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 5);
+    }
+
+    public function testPfmerge() {
+        $this->SetupMemoryStorageCommand(
+            'pfmerge',
+            'POST',
+            '/ms/_pfmerge/key',
+            ['_id' => 'key', 'body' => ['sources' => ['foo', 'bar', 'baz']]],
+            [],
+            'OK'
+        );
+
+        $result = $this->memoryStorage->pfmerge('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 'OK');
+    }
+
+    public function testPing() {
+        $this->SetupMemoryStorageCommand('ping', 'GET', '/ms/_ping' , [], [], 'PONG');
+
+        $result = $this->memoryStorage->ping($this->options);
+        $this->assertEquals($result, 'PONG');
+    }
+
+    public function testPsetex() {
+        $this->SetupMemoryStorageCommand(
+            'psetex',
+            'POST',
+            '/ms/_psetex/key',
+            ['_id' => 'key', 'body' => ['milliseconds' => 42000, 'value' => 'foo']],
+            [],
+            'OK'
+        );
+
+        $result = $this->memoryStorage->psetex('key', 'foo', 42000, $this->options);
+        $this->assertEquals($result, 'OK');
+    }
+
+    public function testPttl() {
+        $this->SetupMemoryStorageCommand(
+            'pttl',
+            'GET',
+            '/ms/_pttl/key',
+            ['_id' => 'key'],
+            [],
+            43159
+        );
+
+        $result = $this->memoryStorage->pttl('key', $this->options);
+        $this->assertEquals($result, 43159);
+    }
+
+    public function testRandomkey() {
+        $this->SetupMemoryStorageCommand(
+            'randomkey',
+            'GET',
+            '/ms/_randomkey',
+            [],
+            [],
+            'foobar'
+        );
+
+        $result = $this->memoryStorage->randomkey($this->options);
+        $this->assertEquals($result, 'foobar');
+    }
+
+    public function testRename() {
+        $this->SetupMemoryStorageCommand(
+            'rename',
+            'POST',
+            '/ms/_rename/key',
+            ['_id' => 'key', 'body' => ['newkey' => 'foo']],
+            [],
+            'OK'
+        );
+
+        $result = $this->memoryStorage->rename('key', 'foo', $this->options);
+        $this->assertEquals($result, 'OK');
+    }
+
+    public function testRenamenx() {
+        $this->SetupMemoryStorageCommand(
+            'renamenx',
+            'POST',
+            '/ms/_renamenx/key',
+            ['_id' => 'key', 'body' => ['newkey' => 'foo']],
+            [],
+            'OK'
+        );
+
+        $result = $this->memoryStorage->renamenx('key', 'foo', $this->options);
+        $this->assertEquals($result, 'OK');
+    }
+
+    public function testRpop() {
+        $this->SetupMemoryStorageCommand(
+            'rpop',
+            'POST',
+            '/ms/_rpop/key',
+            ['_id' => 'key'],
+            [],
+            'foobar'
+        );
+
+        $result = $this->memoryStorage->rpop('key', $this->options);
+        $this->assertEquals($result, 'foobar');
+    }
+
+    public function testRpoplpush() {
+        $this->SetupMemoryStorageCommand(
+            'rpoplpush',
+            'POST',
+            '/ms/_rpoplpush',
+            ['body' => ['source' => 'foo', 'destination' => 'bar']],
+            [],
+            'foobar'
+        );
+
+        $result = $this->memoryStorage->rpoplpush('foo', 'bar', $this->options);
+        $this->assertEquals($result, 'foobar');
+    }
+
+    public function testRpush() {
+        $this->SetupMemoryStorageCommand(
+            'rpush',
+            'POST',
+            '/ms/_rpush/key',
+            ['_id' => 'key', 'body' => ['values' => ['foo', 'bar', 'baz']]],
+            [],
+            8
+        );
+
+        $result = $this->memoryStorage->rpush('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 8);
+    }
+
+    public function testRpushx() {
+        $this->SetupMemoryStorageCommand(
+            'rpushx',
+            'POST',
+            '/ms/_rpushx/key',
+            ['_id' => 'key', 'body' => ['value' => 'foobar']],
+            [],
+            8
+        );
+
+        $result = $this->memoryStorage->rpushx('key', 'foobar', $this->options);
+        $this->assertEquals($result, 8);
+    }
+
+    public function testSadd() {
+        $this->SetupMemoryStorageCommand(
+            'sadd',
+            'POST',
+            '/ms/_sadd/key',
+            ['_id' => 'key', 'body' => ['members' => ['foo', 'bar', 'baz']]],
+            [],
+            8
+        );
+
+        $result = $this->memoryStorage->sadd('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 8);
+    }
+
+    public function testScan() {
+        $this->SetupMemoryStorageCommand(
+            'scan',
+            'GET',
+            '/ms/_scan',
+            [],
+            ['cursor' => 0, 'count' => 10, 'match' => 'foo*'],
+            [18, ['foo', 'bar', 'baz', 'qux']]
+        );
+
+        $this->options['count'] = 10;
+        $this->options['match'] = 'foo*';
+
+        $result = $this->memoryStorage->scan(0, $this->options);
+        $this->assertEquals($result, [18, ['foo', 'bar', 'baz', 'qux']]);
+    }
+
+    public function testScard() {
+        $this->SetupMemoryStorageCommand(
+            'scard',
+            'GET',
+            '/ms/_scard/key',
+            ['_id' => 'key'],
+            [],
+            5
+        );
+
+        $result = $this->memoryStorage->scard('key', $this->options);
+        $this->assertEquals($result, 5);
+    }
+
+    public function testSdiff() {
+        $this->SetupMemoryStorageCommand(
+            'sdiff',
+            'GET',
+            '/ms/_sdiff/key',
+            ['_id' => 'key'],
+            ['keys' => 'foo,bar,baz'],
+            ['Excuse me', 'while I', 'kiss the sky']
+        );
+
+        $result = $this->memoryStorage->sdiff('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, ['Excuse me', 'while I', 'kiss the sky']);
+    }
+
+    public function testSdiffstore() {
+        $this->SetupMemoryStorageCommand(
+            'sdiffstore',
+            'POST',
+            '/ms/_sdiffstore/key',
+            ['_id' => 'key', 'body' => ['keys' => ['foo', 'bar', 'baz'], 'destination' => 'foobar']],
+            [],
+            3
+        );
+
+        $result = $this->memoryStorage->sdiffstore('key', ['foo', 'bar', 'baz'], 'foobar', $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testSet() {
+        $this->SetupMemoryStorageCommand(
+            'set',
+            'POST',
+            '/ms/_set/key',
+            [
+                '_id' => 'key',
+                'body' => [
+                    'value' => 'foobar',
+                    'ex' => 42,
+                    'px' => 42000,
+                    'nx' => true,
+                    'xx' => true
+                ]
+            ],
+            [],
+            3
+        );
+
+        $this->options['ex'] = 42;
+        $this->options['px'] = 42000;
+        $this->options['nx'] = true;
+        $this->options['xx'] = true;
+
+        $result = $this->memoryStorage->set('key', 'foobar', $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testSetex() {
+        $this->SetupMemoryStorageCommand(
+            'setex',
+            'POST',
+            '/ms/_setex/key',
+            ['_id' => 'key','body' => ['value' => 'foobar', 'seconds' => 42]],
+            [],
+            'OK'
+        );
+
+        $result = $this->memoryStorage->setex('key', 'foobar', 42, $this->options);
+        $this->assertEquals($result, 'OK');
+    }
+
+    public function testSetnx() {
+        $this->SetupMemoryStorageCommand(
+            'setnx',
+            'POST',
+            '/ms/_setnx/key',
+            ['_id' => 'key','body' => ['value' => 'foobar']],
+            [],
+            1
+        );
+
+        $result = $this->memoryStorage->setnx('key', 'foobar', $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testSinter() {
+        $this->SetupMemoryStorageCommand(
+            'sinter',
+            'GET',
+            '/ms/_sinter',
+            [],
+            ['keys' => 'foo,bar,baz'],
+            ['Excuse me', 'while I', 'kiss the sky']
+        );
+
+        $result = $this->memoryStorage->sinter(['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, ['Excuse me', 'while I', 'kiss the sky']);
+    }
+
+    public function testSinterstore() {
+        $this->SetupMemoryStorageCommand(
+            'sinterstore',
+            'POST',
+            '/ms/_sinterstore',
+            ['body' => ['keys' => ['foo', 'bar', 'baz'], 'destination' => 'foobar']],
+            [],
+            3
+        );
+
+        $result = $this->memoryStorage->sinterstore('foobar', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testSismember() {
+        $this->SetupMemoryStorageCommand(
+            'sismember',
+            'GET',
+            '/ms/_sismember/key/foobar',
+            ['_id' => 'key'],
+            [],
+            1
+        );
+
+        $result = $this->memoryStorage->sismember('key', 'foobar', $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testSmembers() {
+        $this->SetupMemoryStorageCommand(
+            'smembers',
+            'GET',
+            '/ms/_smembers/key',
+            ['_id' => 'key'],
+            [],
+            ['foo', 'bar', 'baz']
+        );
+
+        $result = $this->memoryStorage->smembers('key', $this->options);
+        $this->assertEquals($result, ['foo', 'bar', 'baz']);
+    }
+
+    public function testSmove() {
+        $this->SetupMemoryStorageCommand(
+            'smove',
+            'POST',
+            '/ms/_smove/key',
+            ['_id' => 'key', 'body' => ['destination' => 'foo', 'member' => 'bar']],
+            [],
+            1
+        );
+
+        $result = $this->memoryStorage->smove('key', 'foo', 'bar', $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testSort() {
+        $this->SetupMemoryStorageCommand(
+            'sort',
+            'POST',
+            '/ms/_sort/key',
+            [
+                '_id' => 'key',
+                'body' => [
+                    'alpha' => true,
+                    'by' => 'foo*',
+                    'direction' => 'desc',
+                    'get' => ['foo', 'bar'],
+                    'limit' => ['offset' => 13, 'count' => 42]
+                ]
+            ],
+            [],
+            ['foo', 'bar', 'baz']
+        );
+
+        $this->options['alpha'] = true;
+        $this->options['by'] = 'foo*';
+        $this->options['direction'] = 'desc';
+        $this->options['get'] = ['foo', 'bar'];
+        $this->options['limit'] = ['offset' => 13, 'count' => 42];
+
+        $result = $this->memoryStorage->sort('key', $this->options);
+        $this->assertEquals($result, ['foo', 'bar', 'baz']);
+    }
+
+    public function testSpop() {
+        $this->SetupMemoryStorageCommand(
+            'spop',
+            'POST',
+            '/ms/_spop/key',
+            ['_id' => 'key', 'body' => ['count' => 42]],
+            [],
+            'foo'
+        );
+
+        $this->options['count'] = 42;
+
+        $result = $this->memoryStorage->spop('key', $this->options);
+        $this->assertEquals($result, ['foo']);
+    }
+
+    public function testSrandmember() {
+        $this->SetupMemoryStorageCommand(
+            'srandmember',
+            'GET',
+            '/ms/_srandmember/key',
+            ['_id' => 'key'],
+            ['count' => 42],
+            'foo'
+        );
+
+        $this->options['count'] = 42;
+
+        $result = $this->memoryStorage->srandmember('key', $this->options);
+        $this->assertEquals($result, ['foo']);
+    }
+
+    public function testSrem() {
+        $this->SetupMemoryStorageCommand(
+            'srem',
+            'DELETE',
+            '/ms/_srem/key',
+            ['_id' => 'key', 'body' => ['members' => ['foo', 'bar', 'baz']]],
+            [],
+            3
+        );
+
+        $result = $this->memoryStorage->srem('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testSscan() {
+        $this->SetupMemoryStorageCommand(
+            'sscan',
+            'GET',
+            '/ms/_sscan/key',
+            ['_id' => 'key'],
+            ['cursor' => 0, 'count' => 10, 'match' => 'foo*'],
+            [18, ['foo', 'bar', 'baz', 'qux']]
+        );
+
+        $this->options['count'] = 10;
+        $this->options['match'] = 'foo*';
+
+        $result = $this->memoryStorage->sscan('key', 0, $this->options);
+        $this->assertEquals($result, [18, ['foo', 'bar', 'baz', 'qux']]);
+    }
+
+    public function testStrlen() {
+        $this->SetupMemoryStorageCommand(
+            'strlen',
+            'GET',
+            '/ms/_strlen/key',
+            ['_id' => 'key'],
+            [],
+            5
+        );
+
+        $result = $this->memoryStorage->strlen('key', $this->options);
+        $this->assertEquals($result, 5);
+    }
+
+    public function testSunion() {
+        $this->SetupMemoryStorageCommand(
+            'sunion',
+            'GET',
+            '/ms/_sunion',
+            [],
+            ['keys' => 'foo,bar,baz'],
+            ['Excuse me', 'while I', 'kiss the sky']
+        );
+
+        $result = $this->memoryStorage->sunion(['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, ['Excuse me', 'while I', 'kiss the sky']);
+    }
+
+    public function testSunionstore() {
+        $this->SetupMemoryStorageCommand(
+            'sunionstore',
+            'POST',
+            '/ms/_sunionstore',
+            ['body' => ['keys' => ['foo', 'bar', 'baz'], 'destination' => 'foobar']],
+            [],
+            3
+        );
+
+        $result = $this->memoryStorage->sunionstore('foobar', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testTime() {
+        $this->SetupMemoryStorageCommand('time', 'GET', '/ms/_time' , [], [], [1234657890, 42]);
+
+        $result = $this->memoryStorage->time($this->options);
+        $this->assertEquals($result, [1234657890, 42]);
+    }
+
+    public function testTouch() {
+        $this->SetupMemoryStorageCommand(
+            'touch',
+            'POST',
+            '/ms/_touch',
+            ['body' => ['keys' => ['foo', 'bar', 'baz']]],
+            [],
+            3
+        );
+
+        $result = $this->memoryStorage->touch(['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testTtl() {
+        $this->SetupMemoryStorageCommand(
+            'ttl',
+            'GET',
+            '/ms/_ttl/key',
+            ['_id' => 'key'],
+            [],
+            42
+        );
+
+        $result = $this->memoryStorage->ttl('key', $this->options);
+        $this->assertEquals($result, 42);
+    }
+
+    public function testType() {
+        $this->SetupMemoryStorageCommand(
+            'type',
+            'GET',
+            '/ms/_type/key',
+            ['_id' => 'key'],
+            [],
+            'zset'
+        );
+
+        $result = $this->memoryStorage->type('key', $this->options);
+        $this->assertEquals($result, 'zset');
+    }
+
+    public function testZadd() {
+        $elements = [
+            ['score' => 1, 'member' => 'foo'],
+            ['score' => 2, 'member' => 'bar'],
+            ['score' => 3, 'member' => 'baz']
+        ];
+
+        $this->SetupMemoryStorageCommand(
+            'zadd',
+            'POST',
+            '/ms/_zadd/key',
+            [
+                '_id' => 'key',
+                'body' => [
+                    'elements' => $elements,
+                    'nx' => true,
+                    'xx' => false,
+                    'ch' => true,
+                    'incr' => false
+                ]
+            ],
+            [],
+            8
+        );
+
+        $this->options['nx'] = true;
+        $this->options['xx'] = false;
+        $this->options['ch'] = true;
+        $this->options['incr'] = false;
+
+        $result = $this->memoryStorage->zadd('key', $elements, $this->options);
+        $this->assertEquals($result, 8);
+    }
+
+    public function testZcard() {
+        $this->SetupMemoryStorageCommand(
+            'zcard',
+            'GET',
+            '/ms/_zcard/key',
+            ['_id' => 'key'],
+            [],
+            5
+        );
+
+        $result = $this->memoryStorage->zcard('key', $this->options);
+        $this->assertEquals($result, 5);
+    }
+
+    public function testZcount() {
+        $this->SetupMemoryStorageCommand(
+            'zcount',
+            'GET',
+            '/ms/_zcount/key',
+            ['_id' => 'key'],
+            ['min' => 10, 'max' => 42],
+            5
+        );
+
+        $result = $this->memoryStorage->zcount('key', 10, 42, $this->options);
+        $this->assertEquals($result, 5);
+    }
+
+    public function testZincrby() {
+        $this->SetupMemoryStorageCommand(
+            'zincrby',
+            'POST',
+            '/ms/_zincrby/key',
+            ['_id' => 'key', 'body' => ['member' => 'foo', 'value' => 42]],
+            [],
+            50
+        );
+
+        $result = $this->memoryStorage->zincrby('key', 'foo', 42, $this->options);
+        $this->assertEquals($result, 50);
+    }
+
+    public function testZinterstore() {
+        $this->SetupMemoryStorageCommand(
+            'zinterstore',
+            'POST',
+            '/ms/_zinterstore/key',
+            [
+                '_id' => 'key',
+                'body' => [
+                    'keys' => ['foo', 'bar', 'baz'],
+                    'weights' => [10, 20, 30],
+                    'aggregate' => 'sum'
+                ]
+            ],
+            [],
+            3
+        );
+
+        $this->options['weights'] = [10, 20, 30];
+        $this->options['aggregate'] = 'sum';
+
+        $result = $this->memoryStorage->zinterstore('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testZlexcount() {
+        $this->SetupMemoryStorageCommand(
+            'zlexcount',
+            'GET',
+            '/ms/_zlexcount/key',
+            ['_id' => 'key'],
+            ['min' => 10, 'max' => 42],
+            5
+        );
+
+        $result = $this->memoryStorage->zlexcount('key', 10, 42, $this->options);
+        $this->assertEquals($result, 5);
+    }
+
     public function testZrange()
     {
         $this->SetupMemoryStorageCommand(
@@ -949,7 +1627,7 @@ class MemoryStorageTest extends TestCase
             'GET',
             '/ms/_zrange/key',
             ['_id' => 'key'],
-            ['start' => 10, 'stop' => 15, 'options' => ['withscores'], 'limit' => '12,42'],
+            ['start' => 10, 'stop' => 15, 'options' => 'withscores', 'limit' => '12,42'],
             ['foo', 1, 'bar', 2, 'baz', 3]);
 
         $this->options['limit'] = [12, 42];
@@ -960,5 +1638,240 @@ class MemoryStorageTest extends TestCase
             ['member' => 'bar', 'score' => 2],
             ['member' => 'baz', 'score' => 3]
         ], $result);
+    }
+
+    public function testZrangebylex() {
+        $this->SetupMemoryStorageCommand(
+            'zrangebylex',
+            'GET',
+            '/ms/_zrangebylex/key',
+            ['_id' => 'key'],
+            ['min' => 10, 'max' => 42, 'limit' => '10,42'],
+            ['foo', 'bar', 'baz']
+        );
+
+        $this->options['limit'] = [10, 42];
+
+
+        $result = $this->memoryStorage->zrangebylex('key', 10, 42, $this->options);
+        $this->assertEquals($result, ['foo', 'bar', 'baz']);
+    }
+
+    public function testZrangebyscore() {
+        $this->SetupMemoryStorageCommand(
+            'zrangebyscore',
+            'GET',
+            '/ms/_zrangebyscore/key',
+            ['_id' => 'key'],
+            ['min' => 10, 'max' => 42, 'limit' => '10,42', 'options' => 'withscores'],
+            ['foo', 1, 'bar', 2, 'baz', 3]
+        );
+
+        $this->options['limit'] = [10, 42];
+
+
+        $result = $this->memoryStorage->zrangebyscore('key', 10, 42, $this->options);
+        $this->assertEquals($result, [
+            ['member' => 'foo', 'score' => 1],
+            ['member' => 'bar', 'score' => 2],
+            ['member' => 'baz', 'score' => 3]
+        ]);
+    }
+
+    public function testZrank() {
+        $this->SetupMemoryStorageCommand(
+            'zrank',
+            'GET',
+            '/ms/_zrank/key/foobar',
+            ['_id' => 'key'],
+            [],
+            1
+        );
+
+        $result = $this->memoryStorage->zrank('key', 'foobar', $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testZrem() {
+        $this->SetupMemoryStorageCommand(
+            'zrem',
+            'DELETE',
+            '/ms/_zrem/key',
+            ['_id' => 'key', 'body' => ['members' => ['foo', 'bar', 'baz']]],
+            [],
+            3
+        );
+
+        $result = $this->memoryStorage->zrem('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testZremrangebylex() {
+        $this->SetupMemoryStorageCommand(
+            'zremrangebylex',
+            'DELETE',
+            '/ms/_zremrangebylex/key',
+            ['_id' => 'key', 'body' => ['min' => 10, 'max' => 42]],
+            [],
+            3
+        );
+
+        $result = $this->memoryStorage->zremrangebylex('key', 10, 42, $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testZremrangebyrank() {
+        $this->SetupMemoryStorageCommand(
+            'zremrangebyrank',
+            'DELETE',
+            '/ms/_zremrangebyrank/key',
+            ['_id' => 'key', 'body' => ['start' => 10, 'stop' => 42]],
+            [],
+            3
+        );
+
+        $result = $this->memoryStorage->zremrangebyrank('key', 10, 42, $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testZremrangebyscore() {
+        $this->SetupMemoryStorageCommand(
+            'zremrangebyscore',
+            'DELETE',
+            '/ms/_zremrangebyscore/key',
+            ['_id' => 'key', 'body' => ['min' => 10, 'max' => 42]],
+            [],
+            3
+        );
+
+        $result = $this->memoryStorage->zremrangebyscore('key', 10, 42, $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testZrevrange()
+    {
+        $this->SetupMemoryStorageCommand(
+            'zrevrange',
+            'GET',
+            '/ms/_zrevrange/key',
+            ['_id' => 'key'],
+            ['start' => 10, 'stop' => 15, 'options' => 'withscores', 'limit' => '12,42'],
+            ['foo', 1, 'bar', 2, 'baz', 3]);
+
+        $this->options['limit'] = [12, 42];
+        $result = $this->memoryStorage->zrevrange('key', 10, 15, $this->options);
+
+        $this->assertEquals([
+            ['member' => 'foo', 'score' => 1],
+            ['member' => 'bar', 'score' => 2],
+            ['member' => 'baz', 'score' => 3]
+        ], $result);
+    }
+
+    public function testZrevrangebylex() {
+        $this->SetupMemoryStorageCommand(
+            'zrevrangebylex',
+            'GET',
+            '/ms/_zrevrangebylex/key',
+            ['_id' => 'key'],
+            ['min' => 10, 'max' => 42, 'limit' => '10,42'],
+            ['foo', 'bar', 'baz']
+        );
+
+        $this->options['limit'] = [10, 42];
+
+
+        $result = $this->memoryStorage->zrevrangebylex('key', 10, 42, $this->options);
+        $this->assertEquals($result, ['foo', 'bar', 'baz']);
+    }
+
+    public function testZrevrangebyscore() {
+        $this->SetupMemoryStorageCommand(
+            'zrevrangebyscore',
+            'GET',
+            '/ms/_zrevrangebyscore/key',
+            ['_id' => 'key'],
+            ['min' => 10, 'max' => 42, 'limit' => '10,42', 'options' => 'withscores'],
+            ['foo', 1, 'bar', 2, 'baz', 3]
+        );
+
+        $this->options['limit'] = [10, 42];
+
+
+        $result = $this->memoryStorage->zrevrangebyscore('key', 10, 42, $this->options);
+        $this->assertEquals($result, [
+            ['member' => 'foo', 'score' => 1],
+            ['member' => 'bar', 'score' => 2],
+            ['member' => 'baz', 'score' => 3]
+        ]);
+    }
+
+    public function testZrevrank() {
+        $this->SetupMemoryStorageCommand(
+            'zrevrank',
+            'GET',
+            '/ms/_zrevrank/key/foobar',
+            ['_id' => 'key'],
+            [],
+            1
+        );
+
+        $result = $this->memoryStorage->zrevrank('key', 'foobar', $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testZscan() {
+        $this->SetupMemoryStorageCommand(
+            'zscan',
+            'GET',
+            '/ms/_zscan/key',
+            ['_id' => 'key'],
+            ['cursor' => 0, 'count' => 10, 'match' => 'foo*'],
+            [18, ['foo', 'bar', 'baz', 'qux']]
+        );
+
+        $this->options['count'] = 10;
+        $this->options['match'] = 'foo*';
+
+        $result = $this->memoryStorage->zscan('key', 0, $this->options);
+        $this->assertEquals($result, [18, ['foo', 'bar', 'baz', 'qux']]);
+    }
+
+    public function testZscore() {
+        $this->SetupMemoryStorageCommand(
+            'zscore',
+            'GET',
+            '/ms/_zscore/key/foobar',
+            ['_id' => 'key'],
+            [],
+            1
+        );
+
+        $result = $this->memoryStorage->zscore('key', 'foobar', $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testZunionstore() {
+        $this->SetupMemoryStorageCommand(
+            'zunionstore',
+            'POST',
+            '/ms/_zunionstore/key',
+            [
+                '_id' => 'key',
+                'body' => [
+                    'keys' => ['foo', 'bar', 'baz'],
+                    'weights' => [10, 20, 30],
+                    'aggregate' => 'sum'
+                ]
+            ],
+            [],
+            3
+        );
+
+        $this->options['weights'] = [10, 20, 30];
+        $this->options['aggregate'] = 'sum';
+
+        $result = $this->memoryStorage->zunionstore('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 3);
     }
 }

--- a/tests/MemoryStorageTest.php
+++ b/tests/MemoryStorageTest.php
@@ -1844,11 +1844,11 @@ class MemoryStorageTest extends TestCase
             '/ms/_zscore/key/foobar',
             ['_id' => 'key'],
             [],
-            1
+            '3.14159'
         );
 
         $result = $this->memoryStorage->zscore('key', 'foobar', $this->options);
-        $this->assertEquals($result, 1);
+        $this->assertEquals($result, 3.14159);
     }
 
     public function testZunionstore() {

--- a/tests/MemoryStorageTest.php
+++ b/tests/MemoryStorageTest.php
@@ -29,7 +29,6 @@ class MemoryStorageTest extends \PHPUnit_Framework_TestCase
         $id = uniqid();
         $start = 10;
         $stop = 15;
-        $opts = ['withscores' => true];
 
         try {
             $kuzzle = $this
@@ -43,18 +42,16 @@ class MemoryStorageTest extends \PHPUnit_Framework_TestCase
             ];
 
             $httpRequest = [
-                'route' => '/ms/_zrevrange/' . $id . '/' . $start . '/' . $stop,
+                'route' => '/ms/_zrevrange/' . $id,
                 'request' => [
                     'action' => 'zrevrange',
                     'controller' => 'memoryStorage',
                     'metadata' => [],
                     'requestId' => $options['requestId'],
                     '_id' => $id,
-                    'body' => [
-                        'start' => $start,
-                        'stop' => $stop,
-                        'withscores' => $opts['withscores']
-                    ]
+                    'start' => $start,
+                    'stop' => $stop,
+                    'withscores' => $opts['withscores']
                 ],
                 'method' => 'GET',
                 'query_parameters' => []
@@ -73,7 +70,7 @@ class MemoryStorageTest extends \PHPUnit_Framework_TestCase
              */
             $memoryStorage = $kuzzle->memoryStorage();
 
-            $memoryStorage->zrevrange($id, $start, $stop, $opts, $options);
+            $memoryStorage->zrevrange($id, $start, $stop, $options);
         }
         catch (Exception $e) {
             $this->fail('MemoryStorageTest::testCommand => Should not raise an exception');

--- a/tests/MemoryStorageTest.php
+++ b/tests/MemoryStorageTest.php
@@ -6,19 +6,49 @@ class MemoryStorageTest extends \PHPUnit_Framework_TestCase
 {
     public function testCallUndefinedCommand()
     {
-        // Arrange
-        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $kuzzle = new Kuzzle(KuzzleTest::FAKE_KUZZLE_HOST);
+        $memoryStorage = $kuzzle->memoryStorage();
 
         try {
-            $kuzzle = new Kuzzle($url);
-            $memoryStorage = $kuzzle->memoryStorage();
-
             $memoryStorage->undefined();
             $this->fail('MemoryStorageTest::testCallUndefinedCommand => Should raise an exception');
         }
         catch (Exception $e) {
             $this->assertInstanceOf('InvalidArgumentException', $e);
             $this->assertEquals('MemoryStorage: Command "undefined" not found', $e->getMessage());
+        }
+    }
+
+    public function testWrongNumberOfArguments()
+    {
+        $kuzzle = new Kuzzle(KuzzleTest::FAKE_KUZZLE_HOST);
+        $memoryStorage = $kuzzle->memoryStorage();
+
+        try {
+            $memoryStorage->dbsize('foo', []);
+            $this->fail('MemoryStorageTest::testWrongNumberOfArguments(dbsize) => Should raise an exception');
+        }
+        catch (Exception $e) {
+            $this->assertInstanceOf('InvalidArgumentException', $e);
+            $this->assertEquals('MemoryStorage.dbsize: Too many parameters provided', $e->getMessage());
+        }
+
+        try {
+            $memoryStorage->mget();
+            $this->fail('MemoryStorageTest::testWrongNumberOfArguments(mget) => Should raise an exception');
+        }
+        catch (Exception $e) {
+            $this->assertInstanceOf('InvalidArgumentException', $e);
+            $this->assertEquals('MemoryStorage.mget: Missing parameter "keys"', $e->getMessage());
+        }
+
+        try {
+            $memoryStorage->ping(123);
+            $this->fail('MemoryStorageTest::testWrongNumberOfArguments(ping) => Should raise an exception');
+        }
+        catch (Exception $e) {
+            $this->assertInstanceOf('InvalidArgumentException', $e);
+            $this->assertEquals('MemoryStorage.ping: Invalid optional parameter (expected an associative array)', $e->getMessage());
         }
     }
 
@@ -30,50 +60,45 @@ class MemoryStorageTest extends \PHPUnit_Framework_TestCase
         $start = 10;
         $stop = 15;
 
-        try {
-            $kuzzle = $this
-                ->getMockBuilder('\Kuzzle\Kuzzle')
-                ->setMethods(['emitRestRequest'])
-                ->setConstructorArgs([$url])
-                ->getMock();
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
 
-            $options = [
-                'requestId' => uniqid()
-            ];
+        $options = [
+            'requestId' => uniqid()
+        ];
 
-            $httpRequest = [
-                'route' => '/ms/_zrevrange/' . $id,
-                'request' => [
-                    'action' => 'zrevrange',
-                    'controller' => 'memoryStorage',
-                    'metadata' => [],
-                    'requestId' => $options['requestId'],
-                    '_id' => $id,
-                    'start' => $start,
-                    'stop' => $stop,
-                    'withscores' => $opts['withscores']
-                ],
-                'method' => 'GET',
-                'query_parameters' => []
-            ];
+        $httpRequest = [
+            'route' => '/ms/_zrevrange/' . $id,
+            'request' => [
+                'action' => 'zrevrange',
+                'controller' => 'memoryStorage',
+                'metadata' => [],
+                'requestId' => $options['requestId'],
+                '_id' => $id,
+                'start' => $start,
+                'stop' => $stop,
+                'options' => ['withscores']
+            ],
+            'method' => 'GET',
+            'query_parameters' => []
+        ];
 
-            $httpResponse = [];
+        $httpResponse = [];
 
-            $kuzzle
-                ->expects($this->once())
-                ->method('emitRestRequest')
-                ->with($httpRequest)
-                ->willReturn($httpResponse);
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
 
-            /**
-             * @var Kuzzle $kuzzle
-             */
-            $memoryStorage = $kuzzle->memoryStorage();
+        /**
+         * @var Kuzzle $kuzzle
+         */
+        $memoryStorage = $kuzzle->memoryStorage();
 
-            $memoryStorage->zrevrange($id, $start, $stop, $options);
-        }
-        catch (Exception $e) {
-            $this->fail('MemoryStorageTest::testCommand => Should not raise an exception');
-        }
+        $memoryStorage->zrevrange($id, $start, $stop, $options);
     }
 }

--- a/tests/MemoryStorageTest.php
+++ b/tests/MemoryStorageTest.php
@@ -1,12 +1,35 @@
 <?php
 
 use Kuzzle\Kuzzle;
+use Kuzzle\MemoryStorage;
+use PHPUnit\Framework\TestCase;
 
-class MemoryStorageTest extends \PHPUnit_Framework_TestCase
+
+class MemoryStorageTest extends TestCase
 {
+    protected $url = KuzzleTest::FAKE_KUZZLE_HOST;
+    /**
+     * @var Kuzzle $kuzzle
+     */
+    protected $kuzzle = null;
+    protected $memoryStorage;
+    protected $options;
+
+    protected function SetUp() {
+        $this->options = ['requestId' => uniqid()];
+
+        $this->kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$this->url])
+            ->getMock();
+
+        $this->memoryStorage = new MemoryStorage($this->kuzzle);
+    }
+
     public function testCallUndefinedCommand()
     {
-        $kuzzle = new Kuzzle(KuzzleTest::FAKE_KUZZLE_HOST);
+        $kuzzle = new Kuzzle($this->url);
         $memoryStorage = $kuzzle->memoryStorage();
 
         try {
@@ -19,9 +42,40 @@ class MemoryStorageTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @param {string} $command
+     * @param {string} $verb
+     * @param {string} $route
+     * @param {array} $request
+     * @param {array} $opts
+     * @param $response
+     */
+    private function SetupMemoryStorageCommand($command, $verb, $route, $request, $opts, $response)
+    {
+        $httpRequest = [
+            'route' => $route,
+            'request' => [
+                'action' => $command,
+                'controller' => 'memoryStorage',
+                'metadata' => [],
+                'requestId' => $this->options['requestId'],
+            ],
+            'method' => $verb,
+            'query_parameters' => $opts
+        ];
+
+        $httpRequest['request'] = array_merge($httpRequest['request'], $request);
+
+        $this->kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn(['result' => $response]);
+    }
+
     public function testWrongNumberOfArguments()
     {
-        $kuzzle = new Kuzzle(KuzzleTest::FAKE_KUZZLE_HOST);
+        $kuzzle = new Kuzzle($this->url);
         $memoryStorage = $kuzzle->memoryStorage();
 
         try {
@@ -52,53 +106,859 @@ class MemoryStorageTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testCommand()
-    {
-        // Arrange
-        $url = KuzzleTest::FAKE_KUZZLE_HOST;
-        $id = uniqid();
-        $start = 10;
-        $stop = 15;
+    public function testAppend() {
+        $this->SetupMemoryStorageCommand('append', 'POST', '/ms/_append/key', [
+           '_id' => 'key',
+            'body' => ['value' => 'foo']
+        ], [], 3);
 
-        $kuzzle = $this
-            ->getMockBuilder('\Kuzzle\Kuzzle')
-            ->setMethods(['emitRestRequest'])
-            ->setConstructorArgs([$url])
-            ->getMock();
+        $result = $this->memoryStorage->append('key', 'foo', $this->options);
+        $this->assertEquals($result, 3);
+    }
 
-        $options = [
-            'requestId' => uniqid()
-        ];
+    public function testBitcount() {
+        $this->SetupMemoryStorageCommand(
+            'bitcount',
+            'GET',
+            '/ms/_bitcount/key',
+            ['_id' => 'key'],
+            ['start' => 1, 'end' => 3],
+            3
+        );
 
-        $httpRequest = [
-            'route' => '/ms/_zrevrange/' . $id,
-            'request' => [
-                'action' => 'zrevrange',
-                'controller' => 'memoryStorage',
-                'metadata' => [],
-                'requestId' => $options['requestId'],
-                '_id' => $id,
-                'start' => $start,
-                'stop' => $stop,
-                'options' => ['withscores']
+        $this->options['start'] = 1;
+        $this->options['end'] = 3;
+
+        $result = $this->memoryStorage->bitcount('key', $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testBitop() {
+        $this->SetupMemoryStorageCommand('bitop', 'POST', '/ms/_bitop/key', [
+            '_id' => 'key',
+            'body' => [
+                'operation' => 'AND',
+                'keys' => ['foo', 'bar', 'baz']
+            ]
+        ], [], 3);
+
+        $result = $this->memoryStorage->bitop('key', 'AND', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testBitpos() {
+        $this->SetupMemoryStorageCommand(
+            'bitpos',
+            'GET',
+            '/ms/_bitpos/key',
+            ['_id' => 'key'],
+            ['start' => 1, 'end' => 3, 'bit' => 0],
+            3
+        );
+
+        $this->options['start'] = 1;
+        $this->options['end'] = 3;
+
+        $result = $this->memoryStorage->bitpos('key', 0, $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testDbsize() {
+        $this->SetupMemoryStorageCommand('dbsize', 'GET', '/ms/_dbsize' , [], [], 3);
+
+        $result = $this->memoryStorage->dbsize($this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testDecr() {
+        $this->SetupMemoryStorageCommand('decr', 'POST', '/ms/_decr/key', [
+            '_id' => 'key'
+        ], [], 'foobar');
+
+        $result = $this->memoryStorage->decr('key', $this->options);
+        $this->assertEquals($result, 'foobar');
+    }
+
+    public function testDecrby() {
+        $this->SetupMemoryStorageCommand('decrby', 'POST', '/ms/_decrby/key', [
+            '_id' => 'key',
+            'body' => ['value' => 42]
+        ], [], 47);
+
+        $result = $this->memoryStorage->decrby('key', 42, $this->options);
+        $this->assertEquals($result, 47);
+    }
+
+    public function testDel() {
+        $this->SetupMemoryStorageCommand('del', 'DELETE', '/ms', [
+            'body' => ['keys' => ['foo', 'bar', 'baz']]
+        ], [], 3);
+
+        $result = $this->memoryStorage->del(['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testExists() {
+        $this->SetupMemoryStorageCommand('exists', 'GET', '/ms/_exists', [],
+        ['keys' => 'foo,bar,baz'], 3);
+
+        $result = $this->memoryStorage->exists(['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testExpire() {
+        $this->SetupMemoryStorageCommand('expire', 'POST', '/ms/_expire/key', [
+            '_id' => 'key',
+            'body' => ['seconds' => 42]
+        ], [], 0);
+
+        $result = $this->memoryStorage->expire('key', 42, $this->options);
+        $this->assertEquals($result, 0);
+    }
+
+    public function testExpireat() {
+        $this->SetupMemoryStorageCommand('expireat', 'POST', '/ms/_expireat/key', [
+            '_id' => 'key',
+            'body' => ['timestamp' => 1234567890]
+        ], [], 1);
+
+        $result = $this->memoryStorage->expireat('key', 1234567890, $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testFlushdb() {
+        $this->SetupMemoryStorageCommand('flushdb', 'POST', '/ms/_flushdb' , [], [], 1);
+
+        $result = $this->memoryStorage->flushdb($this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testGeoadd() {
+        $points = [
+            [
+                'lon' => 13.361389,
+                'lat' => 38.115556,
+                'name' => 'Palermo'
             ],
-            'method' => 'GET',
-            'query_parameters' => []
+            [
+                'lon' => 15.087269,
+                'lat' => 37.502669,
+                'name' => 'Catania'
+            ]
         ];
 
-        $httpResponse = [];
+        $this->SetupMemoryStorageCommand('geoadd', 'POST', '/ms/_geoadd/key', [
+            '_id' => 'key',
+            'body' => ['points' => $points]
+        ], [], 2);
 
-        $kuzzle
-            ->expects($this->once())
-            ->method('emitRestRequest')
-            ->with($httpRequest)
-            ->willReturn($httpResponse);
+        $result = $this->memoryStorage->geoadd('key', $points, $this->options);
+        $this->assertEquals($result, 2);
+    }
 
-        /**
-         * @var Kuzzle $kuzzle
-         */
-        $memoryStorage = $kuzzle->memoryStorage();
+    public function testGeodist() {
+        $this->SetupMemoryStorageCommand(
+            'geodist',
+            'GET',
+            '/ms/_geodist/key/foo/bar',
+            ['_id' => 'key'],
+            ['unit' => 'ft'],
+            '166274.1516'
+        );
 
-        $memoryStorage->zrevrange($id, $start, $stop, $options);
+        $this->options['unit'] = 'ft';
+
+        $result = $this->memoryStorage->geodist('key', 'foo' , 'bar', $this->options);
+        $this->assertEquals($result, 166274.1516);
+    }
+
+    public function testGeohash() {
+        $this->SetupMemoryStorageCommand(
+            'geohash',
+            'GET',
+            '/ms/_geohash/key',
+            ['_id' => 'key'],
+            ['members' => 'foo,bar,baz'],
+            ['abc', 'def']
+        );
+
+        $result = $this->memoryStorage->geohash('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, ['abc', 'def']);
+    }
+
+    public function testGeopos() {
+        $this->SetupMemoryStorageCommand(
+            'geopos',
+            'GET',
+            '/ms/_geopos/key',
+            ['_id' => 'key'],
+            ['members' => 'foo,bar,baz'],
+            [['12.34', '56.78'], ['3.14', '2.718']]
+        );
+
+        $result = $this->memoryStorage->geopos('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, [[12.34, 56.78], [3.14, 2.718]]);
+    }
+
+    public function testGeoradius() {
+        $this->SetupMemoryStorageCommand(
+            'georadius',
+            'GET',
+            '/ms/_georadius/key',
+            ['_id' => 'key'],
+            [
+                'lon' => 15,
+                'lat' => 37,
+                'distance' => 200,
+                'unit' => 'km',
+                'options' => 'count,10,asc,withcoord,withdist'
+            ],
+            [['Palermo', '190.4424', ['13.36', '38.11']], ['Catania', ['15.08', '37.5'], '56.44']]
+        );
+
+        $this->options['count'] = 10;
+        $this->options['sort'] = 'asc';
+        $this->options['withcoord'] = true;
+        $this->options['withdist'] = true;
+
+        $result = $this->memoryStorage->georadius('key', 15, 37, 200, 'km', $this->options);
+        $this->assertEquals($result, [[
+            'name' => 'Palermo',
+            'distance' => 190.4424,
+            'coordinates' => [13.36, 38.11]
+        ], [
+            'name' => 'Catania',
+            'distance' => 56.44,
+            'coordinates' => [15.08, 37.5]
+        ]]);
+    }
+
+    public function testGeoradiusbymember() {
+        $this->SetupMemoryStorageCommand(
+            'georadiusbymember',
+            'GET',
+            '/ms/_georadiusbymember/key',
+            ['_id' => 'key'],
+            [
+                'member' => 'Palermo',
+                'distance' => 200,
+                'unit' => 'km',
+                'options' => 'count,10,asc,withcoord,withdist'
+            ],
+            [['Palermo', '190.4424', ['13.36', '38.11']], ['Catania', ['15.08', '37.5'], '56.44']]
+        );
+
+        $this->options['count'] = 10;
+        $this->options['sort'] = 'asc';
+        $this->options['withcoord'] = true;
+        $this->options['withdist'] = true;
+
+        $result = $this->memoryStorage->georadiusbymember('key', 'Palermo', 200, 'km', $this->options);
+        $this->assertEquals($result, [[
+            'name' => 'Palermo',
+            'distance' => 190.4424,
+            'coordinates' => [13.36, 38.11]
+        ], [
+            'name' => 'Catania',
+            'distance' => 56.44,
+            'coordinates' => [15.08, 37.5]
+        ]]);
+    }
+
+    public function testGet() {
+        $this->SetupMemoryStorageCommand(
+            'get',
+            'GET',
+            '/ms/key',
+            ['_id' => 'key'],
+            [],
+            'foobar'
+        );
+
+        $result = $this->memoryStorage->get('key', $this->options);
+        $this->assertEquals($result, 'foobar');
+    }
+
+    public function testGetbit() {
+        $this->SetupMemoryStorageCommand(
+            'getbit',
+            'GET',
+            '/ms/_getbit/key',
+            ['_id' => 'key'],
+            ['offset' => 42],
+            0
+        );
+
+        $result = $this->memoryStorage->getbit('key', 42, $this->options);
+        $this->assertEquals($result, 0);
+    }
+
+    public function testGetrange() {
+        $this->SetupMemoryStorageCommand(
+            'getrange',
+            'GET',
+            '/ms/_getrange/key',
+            ['_id' => 'key'],
+            ['start' => 10, 'end' => 42],
+            13
+        );
+
+        $result = $this->memoryStorage->getrange('key', 10, 42, $this->options);
+        $this->assertEquals($result, 13);
+    }
+
+    public function testGetset() {
+        $this->SetupMemoryStorageCommand(
+            'getset',
+            'POST',
+            '/ms/_getset/key',
+            ['_id' => 'key', 'body' => ['value' => 'foobar']],
+            [],
+            'barfoo'
+        );
+
+        $result = $this->memoryStorage->getset('key', 'foobar', $this->options);
+        $this->assertEquals($result, 'barfoo');
+    }
+
+    public function testHdel() {
+        $this->SetupMemoryStorageCommand(
+            'hdel',
+            'DELETE',
+            '/ms/_hdel/key',
+            ['_id' => 'key', 'body' => ['fields' => ['foo', 'bar', 'baz']]],
+            [],
+            3
+        );
+
+        $result = $this->memoryStorage->hdel('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testHexists() {
+        $this->SetupMemoryStorageCommand(
+            'hexists',
+            'GET',
+            '/ms/_hexists/key/foobar',
+            ['_id' => 'key'],
+            [],
+            1
+        );
+
+        $result = $this->memoryStorage->hexists('key', 'foobar', $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testHget() {
+        $this->SetupMemoryStorageCommand(
+            'hget',
+            'GET',
+            '/ms/_hget/key/foobar',
+            ['_id' => 'key'],
+            [],
+            'foobar'
+        );
+
+        $result = $this->memoryStorage->hget('key', 'foobar', $this->options);
+        $this->assertEquals($result, 'foobar');
+    }
+
+    public function testHgetall() {
+        $this->SetupMemoryStorageCommand(
+            'hgetall',
+            'GET',
+            '/ms/_hgetall/key',
+            ['_id' => 'key'],
+            [],
+            ['foo' => 'bar', 'baz' => 'qux']
+        );
+
+        $result = $this->memoryStorage->hgetall('key', $this->options);
+        $this->assertEquals($result, ['foo' => 'bar', 'baz' => 'qux']);
+    }
+
+    public function testHincrby() {
+        $this->SetupMemoryStorageCommand(
+            'hincrby',
+            'POST',
+            '/ms/_hincrby/key',
+            ['_id' => 'key', 'body' => ['field' => 'foo', 'value' => 42]],
+            [],
+            50
+        );
+
+        $result = $this->memoryStorage->hincrby('key', 'foo', 42, $this->options);
+        $this->assertEquals($result, 50);
+    }
+
+    public function testHincrbyfloat() {
+        $this->SetupMemoryStorageCommand(
+            'hincrbyfloat',
+            'POST',
+            '/ms/_hincrbyfloat/key',
+            ['_id' => 'key', 'body' => ['field' => 'foo', 'value' => 42.5]],
+            [],
+            '50.123'
+        );
+
+        $result = $this->memoryStorage->hincrbyfloat('key', 'foo', 42.5, $this->options);
+        $this->assertEquals($result, 50.123);
+    }
+
+    public function testHkeys() {
+        $this->SetupMemoryStorageCommand(
+            'hkeys',
+            'GET',
+            '/ms/_hkeys/key',
+            ['_id' => 'key'],
+            [],
+            ['foo', 'bar', 'baz']
+        );
+
+        $result = $this->memoryStorage->hkeys('key', $this->options);
+        $this->assertEquals($result, ['foo', 'bar', 'baz']);
+    }
+
+    public function testHlen() {
+        $this->SetupMemoryStorageCommand(
+            'hlen',
+            'GET',
+            '/ms/_hlen/key',
+            ['_id' => 'key'],
+            [],
+            5
+        );
+
+        $result = $this->memoryStorage->hlen('key', $this->options);
+        $this->assertEquals($result, 5);
+    }
+
+    public function testHmget() {
+        $this->SetupMemoryStorageCommand(
+            'hmget',
+            'GET',
+            '/ms/_hmget/key',
+            ['_id' => 'key'],
+            ['fields' => 'foo,bar,baz'],
+            ['hey', 'I just met you', 'and this is crazy']
+        );
+
+        $result = $this->memoryStorage->hmget('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, ['hey', 'I just met you', 'and this is crazy']);
+    }
+
+    public function testHmset() {
+        $entries = [
+            ['field' => 'field1', 'value' => 'foo'],
+            ['field' => 'field2', 'value' => 'bar'],
+            ['field' => '...', 'value' => '...']
+        ];
+
+        $this->SetupMemoryStorageCommand(
+            'hmset',
+            'POST',
+            '/ms/_hmset/key',
+            ['_id' => 'key', 'body' => ['entries' => $entries]],
+            [],
+            'OK'
+        );
+
+        $result = $this->memoryStorage->hmset('key', $entries, $this->options);
+        $this->assertEquals($result, 'OK');
+    }
+
+    public function testHscan() {
+        $this->SetupMemoryStorageCommand(
+            'hscan',
+            'GET',
+            '/ms/_hscan/key',
+            ['_id' => 'key'],
+            ['cursor' => 0],
+            [18, ['foo', 'bar', 'baz', 'qux']]
+        );
+
+        $result = $this->memoryStorage->hscan('key', 0, $this->options);
+        $this->assertEquals($result, [18, ['foo', 'bar', 'baz', 'qux']]);
+    }
+
+    public function testHset() {
+        $this->SetupMemoryStorageCommand(
+            'hset',
+            'POST',
+            '/ms/_hset/key',
+            ['_id' => 'key', 'body' => ['field' => 'foo', 'value' => 'bar']],
+            [],
+            1
+        );
+
+        $result = $this->memoryStorage->hset('key', 'foo', 'bar', $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testHsetnx() {
+        $this->SetupMemoryStorageCommand(
+            'hsetnx',
+            'POST',
+            '/ms/_hsetnx/key',
+            ['_id' => 'key', 'body' => ['field' => 'foo', 'value' => 'bar']],
+            [],
+            1
+        );
+
+        $result = $this->memoryStorage->hsetnx('key', 'foo', 'bar', $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testHstrlen() {
+        $this->SetupMemoryStorageCommand(
+            'hstrlen',
+            'GET',
+            '/ms/_hstrlen/key/foo',
+            ['_id' => 'key'],
+            [],
+            5
+        );
+
+        $result = $this->memoryStorage->hstrlen('key', 'foo', $this->options);
+        $this->assertEquals($result, 5);
+    }
+
+    public function testHvals() {
+        $this->SetupMemoryStorageCommand(
+            'hvals',
+            'GET',
+            '/ms/_hvals/key',
+            ['_id' => 'key'],
+            [],
+            ['foo', 'bar', 'baz']
+        );
+
+        $result = $this->memoryStorage->hvals('key', $this->options);
+        $this->assertEquals($result, ['foo', 'bar', 'baz']);
+    }
+
+    public function testincr() {
+        $this->SetupMemoryStorageCommand(
+            'incr',
+            'POST',
+            '/ms/_incr/key',
+            ['_id' => 'key'],
+            [],
+            50
+        );
+
+        $result = $this->memoryStorage->incr('key', $this->options);
+        $this->assertEquals($result, 50);
+    }
+
+    public function testincrby() {
+        $this->SetupMemoryStorageCommand(
+            'incrby',
+            'POST',
+            '/ms/_incrby/key',
+            ['_id' => 'key', 'body' => ['value' => 42]],
+            [],
+            50
+        );
+
+        $result = $this->memoryStorage->incrby('key', 42, $this->options);
+        $this->assertEquals($result, 50);
+    }
+
+    public function testincrbyfloat() {
+        $this->SetupMemoryStorageCommand(
+            'incrbyfloat',
+            'POST',
+            '/ms/_incrbyfloat/key',
+            ['_id' => 'key', 'body' => ['value' => 42.5]],
+            [],
+            '50.123'
+        );
+
+        $result = $this->memoryStorage->incrbyfloat('key', 42.5, $this->options);
+        $this->assertEquals($result, 50.123);
+    }
+
+    public function testKeys() {
+        $this->SetupMemoryStorageCommand(
+            'keys',
+            'GET',
+            '/ms/_keys/foo*',
+            [],
+            [],
+            ['foo', 'foobar', 'foobarbaz']
+        );
+
+        $result = $this->memoryStorage->keys('foo*', $this->options);
+        $this->assertEquals($result, ['foo', 'foobar', 'foobarbaz']);
+    }
+
+    public function testLindex() {
+        $this->SetupMemoryStorageCommand(
+            'lindex',
+            'GET',
+            '/ms/_lindex/key/3',
+            ['_id' => 'key'],
+            [],
+            'foobar'
+        );
+
+        $result = $this->memoryStorage->lindex('key', 3, $this->options);
+        $this->assertEquals($result, 'foobar');
+    }
+
+    public function testLinsert() {
+        $this->SetupMemoryStorageCommand(
+            'linsert',
+            'POST',
+            '/ms/_linsert/key',
+            [
+                '_id' => 'key',
+                'body' => [
+                    'position' => 'before',
+                    'pivot' => 'foo',
+                    'value' => 'bar'
+                ]
+            ],
+            [],
+            7
+        );
+
+        $result = $this->memoryStorage->linsert('key', 'before', 'foo', 'bar', $this->options);
+        $this->assertEquals($result, 7);
+    }
+
+    public function testLlen() {
+        $this->SetupMemoryStorageCommand(
+            'llen',
+            'GET',
+            '/ms/_llen/key',
+            ['_id' => 'key'],
+            [],
+            5
+        );
+
+        $result = $this->memoryStorage->llen('key', $this->options);
+        $this->assertEquals($result, 5);
+    }
+
+    public function testLpop() {
+        $this->SetupMemoryStorageCommand(
+            'lpop',
+            'POST',
+            '/ms/_lpop/key',
+            ['_id' => 'key'],
+            [],
+            'foobar'
+        );
+
+        $result = $this->memoryStorage->lpop('key', $this->options);
+        $this->assertEquals($result, 'foobar');
+    }
+
+    public function testLpush() {
+        $this->SetupMemoryStorageCommand(
+            'lpush',
+            'POST',
+            '/ms/_lpush/key',
+            ['_id' => 'key', 'body' => ['values' => ['foo', 'bar', 'baz']]],
+            [],
+            8
+        );
+
+        $result = $this->memoryStorage->lpush('key', ['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, 8);
+    }
+
+    public function testLpushx() {
+        $this->SetupMemoryStorageCommand(
+            'lpushx',
+            'POST',
+            '/ms/_lpushx/key',
+            ['_id' => 'key', 'body' => ['value' => 'foobar']],
+            [],
+            8
+        );
+
+        $result = $this->memoryStorage->lpushx('key', 'foobar', $this->options);
+        $this->assertEquals($result, 8);
+    }
+
+    public function testLrange() {
+        $this->SetupMemoryStorageCommand(
+            'lrange',
+            'GET',
+            '/ms/_lrange/key',
+            ['_id' => 'key'],
+            ['start' => 13, 'stop' => 16],
+            ['foo', 'bar', 'baz']
+        );
+
+        $result = $this->memoryStorage->lrange('key', 13, 16, $this->options);
+        $this->assertEquals($result, ['foo', 'bar', 'baz']);
+    }
+
+    public function testLrem() {
+        $this->SetupMemoryStorageCommand(
+            'lrem',
+            'DELETE',
+            '/ms/_lrem/key',
+            ['_id' => 'key', 'body' => ['count' => 3, 'value' => 'foo']],
+            [],
+            3
+        );
+
+        $result = $this->memoryStorage->lrem('key', 3, 'foo', $this->options);
+        $this->assertEquals($result, 3);
+    }
+
+    public function testLset() {
+        $this->SetupMemoryStorageCommand(
+            'lset',
+            'POST',
+            '/ms/_lset/key',
+            ['_id' => 'key', 'body' => ['index' => 3, 'value' => 'bar']],
+            [],
+            'OK'
+        );
+
+        $result = $this->memoryStorage->lset('key', 3, 'bar', $this->options);
+        $this->assertEquals($result, 'OK');
+    }
+
+    public function testLtrim() {
+        $this->SetupMemoryStorageCommand(
+            'ltrim',
+            'POST',
+            '/ms/_ltrim/key',
+            ['_id' => 'key', 'body' => ['start' => 13, 'stop' => 42]],
+            [],
+            'OK'
+        );
+
+        $result = $this->memoryStorage->ltrim('key', 13, 42, $this->options);
+        $this->assertEquals($result, 'OK');
+    }
+
+    public function testMget() {
+        $this->SetupMemoryStorageCommand(
+            'mget',
+            'GET',
+            '/ms/_mget',
+            [],
+            ['keys' => 'foo,bar,baz'],
+            ['Excuse me', 'while I', 'kiss the sky']
+        );
+
+        $result = $this->memoryStorage->mget(['foo', 'bar', 'baz'], $this->options);
+        $this->assertEquals($result, ['Excuse me', 'while I', 'kiss the sky']);
+    }
+
+    public function testMset() {
+        $entries = [
+            ['key' => 'field1', 'value' => 'foo'],
+            ['key' => 'field2', 'value' => 'bar'],
+            ['key' => '...', 'value' => '...']
+        ];
+
+        $this->SetupMemoryStorageCommand(
+            'mset',
+            'POST',
+            '/ms/_mset',
+            ['body' => ['entries' => $entries]],
+            [],
+            'OK'
+        );
+
+        $result = $this->memoryStorage->mset($entries, $this->options);
+        $this->assertEquals($result, 'OK');
+    }
+
+    public function testMsetnx() {
+        $entries = [
+            ['key' => 'field1', 'value' => 'foo'],
+            ['key' => 'field2', 'value' => 'bar'],
+            ['key' => '...', 'value' => '...']
+        ];
+
+        $this->SetupMemoryStorageCommand(
+            'msetnx',
+            'POST',
+            '/ms/_msetnx',
+            ['body' => ['entries' => $entries]],
+            [],
+            'OK'
+        );
+
+        $result = $this->memoryStorage->msetnx($entries, $this->options);
+        $this->assertEquals($result, 'OK');
+    }
+
+    public function testObject() {
+        $this->SetupMemoryStorageCommand(
+            'object',
+            'GET',
+            '/ms/_object/key',
+            ['_id' => 'key'],
+            ['subcommand' => 'refcount'],
+            'foobar'
+        );
+
+        $result = $this->memoryStorage->object('key', 'refcount', $this->options);
+        $this->assertEquals($result, 'foobar');
+    }
+
+    public function testPersist() {
+        $this->SetupMemoryStorageCommand(
+            'persist',
+            'POST',
+            '/ms/_persist/key',
+            ['_id' => 'key'],
+            [],
+            1
+        );
+
+        $result = $this->memoryStorage->persist('key', $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testPexpire() {
+        $this->SetupMemoryStorageCommand('pexpire', 'POST', '/ms/_pexpire/key', [
+            '_id' => 'key',
+            'body' => ['milliseconds' => 42000]
+        ], [], 0);
+
+        $result = $this->memoryStorage->pexpire('key', 42000, $this->options);
+        $this->assertEquals($result, 0);
+    }
+
+    public function testPexpireat() {
+        $this->SetupMemoryStorageCommand('pexpireat', 'POST', '/ms/_pexpireat/key', [
+            '_id' => 'key',
+            'body' => ['timestamp' => 1234567890000]
+        ], [], 1);
+
+        $result = $this->memoryStorage->pexpireat('key', 1234567890000, $this->options);
+        $this->assertEquals($result, 1);
+    }
+
+    public function testZrange()
+    {
+        $this->SetupMemoryStorageCommand(
+            'zrange',
+            'GET',
+            '/ms/_zrange/key',
+            ['_id' => 'key'],
+            ['start' => 10, 'stop' => 15, 'options' => ['withscores'], 'limit' => '12,42'],
+            ['foo', 1, 'bar', 2, 'baz', 3]);
+
+        $this->options['limit'] = [12, 42];
+        $result = $this->memoryStorage->zrange('key', 10, 15, $this->options);
+
+        $this->assertEquals([
+            ['member' => 'foo', 'score' => 1],
+            ['member' => 'bar', 'score' => 2],
+            ['member' => 'baz', 'score' => 3]
+        ], $result);
     }
 }


### PR DESCRIPTION
# Description

Make the `MemoryStorage` object on par with the newly refactored corresponding controller and with the new SDK reference.

# Other changes

* the `Kuzzle.query` function now handles any querystring parameter other than the preset list