### PR TITLE
Add support for the new retryOnConflict option

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -452,11 +452,18 @@ class Collection
         $queryArgs['route'] = '/' . $this->index . '/' . $this->collection . '/' . $documentId . '/_update';
         $queryArgs['method'] = 'put';
 
+        if (isset($options['retryOnConflict'])) {
+            $options['query_parameters']['retryOnConflict'] = $options['retryOnConflict'];
+            unset($options['retryOnConflict']);
+        }
+
         $response = $this->kuzzle->query(
             $queryArgs,
             $this->kuzzle->addHeaders($data, $this->headers),
             $options
         );
+
+        unset($options['query_parameters']['retryOnConflict']);
 
         return (new Document($this, $response['result']['_id']))->refresh($options);
     }

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -1086,7 +1086,9 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                 'index' => $index,
                 '_id' => $documentId,
             ],
-            'query_parameters' => []
+            'query_parameters' => [
+                'retryOnConflict' => 42
+            ]
         ];
         $updateDocumentResponse = [
             '_id' => $documentId,
@@ -1138,7 +1140,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $document = $dataCollection->updateDocument($documentId, $documentContent, ['requestId' => $requestId]);
+        $document = $dataCollection->updateDocument($documentId, $documentContent, ['requestId' => $requestId, 'retryOnConflict' => 42]);
 
         $this->assertInstanceOf('Kuzzle\Document', $document);
         $this->assertAttributeEquals($documentId, 'id', $document);


### PR DESCRIPTION
# Description

Add support for the new `retryOnConflict` option on the `collection.updateDocument` route

# Related issue

https://github.com/kuzzleio/kuzzle/issues/730
