### PR TITLE
Add kuzzle info in Document object

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -67,7 +67,7 @@ class Collection
         );
 
         $response['result']['hits'] = array_map(function ($document) {
-            return new Document($this, $document['_id'], $document['_source']);
+            return new Document($this, $document['_id'], $document['_source'], $document['_meta']);
         }, $response['result']['hits']);
 
 
@@ -90,7 +90,6 @@ class Collection
      * Retrieves next result of a search with scroll query.
      *
      * @param string $scrollId
-     * @param string $scroll
      * @param array $options (optional) arguments
      * @param array $filters (optional) original filters
      * @return SearchResult
@@ -113,7 +112,7 @@ class Collection
         );
 
         $response['result']['hits'] = array_map(function ($document) {
-            return new Document($this, $document['_id'], $document['_source']);
+            return new Document($this, $document['_id'], $document['_source'], $document['_meta']);
         }, $response['result']['hits']);
 
 
@@ -212,9 +211,10 @@ class Collection
         );
 
         $content = $response['result']['_source'];
+        $meta = $response['result']['_meta'];
         $content['_version'] = $response['result']['_version'];
 
-        return new Document($this, $response['result']['_id'], $content);
+        return new Document($this, $response['result']['_id'], $content, $meta);
     }
 
     /**
@@ -243,7 +243,7 @@ class Collection
             $data['_id'] = $filters;
             $action = 'delete';
         } else {
-            $data['body'] = $filters;
+            $data['body'] = ['query' => (object)$filters];
             $action = 'deleteByQuery';
         }
 
@@ -261,11 +261,12 @@ class Collection
      *
      * @param string $id Optional document unique ID
      * @param array $content Optional document content
+     * @param array $meta Document metadata
      * @return Document the newly created Kuzzle\Document object
      */
-    public function document($id = '', array $content = [])
+    public function document($id = '', array $content = [], array $meta = [])
     {
-        return new Document($this, $id, $content);
+        return new Document($this, $id, $content, $meta);
     }
 
     /**
@@ -289,8 +290,9 @@ class Collection
 
         $content = $response['result']['_source'];
         $content['_version'] = $response['result']['_version'];
+        $meta = $response['result']['_meta'];
 
-        return new Document($this, $response['result']['_id'], $content);
+        return new Document($this, $response['result']['_id'], $content, $meta);
     }
 
     /**
@@ -390,8 +392,9 @@ class Collection
 
         $content = $response['result']['_source'];
         $content['_version'] = $response['result']['_version'];
+        $meta = $response['result']['_meta'];
 
-        return new Document($this, $response['result']['_id'], $content);
+        return new Document($this, $response['result']['_id'], $content, $meta);
     }
 
     /**

--- a/src/Document.php
+++ b/src/Document.php
@@ -26,6 +26,11 @@ class Document
     protected $headers = [];
 
     /**
+     * @var array Document metadata
+     */
+    protected $meta;
+
+    /**
      * @var string Unique document identifier
      */
     protected $id;
@@ -41,9 +46,10 @@ class Document
      * @param Collection $kuzzleDataCollection An instantiated KuzzleDataCollection object
      * @param string $documentId ID of an existing document.
      * @param array $content Initializes this document with the provided content
+     * @param array $meta Initializes this document with the provided metadata
      * @return Document
      */
-    public function __construct(Collection $kuzzleDataCollection, $documentId = '', array $content = [])
+    public function __construct(Collection $kuzzleDataCollection, $documentId = '', array $content = [], array $meta = [])
     {
         $this->collection = $kuzzleDataCollection;
 
@@ -58,6 +64,10 @@ class Document
             }
 
             $this->setContent($content, true);
+        }
+
+        if (!empty($meta)) {
+            $this->setMeta($meta, true);
         }
 
         return $this;
@@ -110,10 +120,11 @@ class Document
             $options
         );
 
-        $content = $response['result']['_source'];
-        $content['_version'] = $response['result']['_version'];
+        $documentContent = $response['result']['_source'];
+        $documentContent['_version'] = $response['result']['_version'];
+        $documentMeta = $response['result']['_meta'];
 
-        return new Document($this->collection, $response['result']['_id'], $content);
+        return new Document($this->collection, $response['result']['_id'], $documentContent, $documentMeta);
     }
 
     /**
@@ -191,6 +202,35 @@ class Document
     }
 
     /**
+     * Replaces the current metadata with new metadata.
+     * This is a helper function returning itself, allowing to easily chain calls.
+     *
+     * @param array $meta
+     * @param bool $replace true: replace the current metadata with the provided ones, false: merge it
+     * @return Document
+     */
+    public function setMeta(array $meta, $replace = false)
+    {
+        if ($replace) {
+            $this->meta = $meta;
+        } else {
+            foreach ($meta as $key => $value) {
+                $this->meta[$key] = $value;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMeta()
+    {
+        return $this->meta;
+    }
+
+    /**
      * This is a helper function returning itself, allowing to easily chain calls.
      *
      * @param array $headers New content
@@ -234,7 +274,7 @@ class Document
         }
 
         $data['body'] = $this->content;
-
+        $data['meta'] = $this->meta;
 
         return $data;
     }

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -41,12 +41,18 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                     '_id' => 'test',
                     '_source' => [
                         'foo' => 'bar'
+                    ],
+                    '_meta' => [
+                        'author' => 'foo'
                     ]
                 ],
                 1 => [
                     '_id' => 'test1',
                     '_source' => [
                         'foo' => 'bar'
+                    ],
+                    '_meta' => [
+                        'author' => 'bar'
                     ]
                 ]
             ],
@@ -135,12 +141,18 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                     '_id' => 'test',
                     '_source' => [
                         'foo' => 'bar'
+                    ],
+                    '_meta' => [
+                        'author' => 'foo'
                     ]
                 ],
                 1 => [
                     '_id' => 'test1',
                     '_source' => [
                         'foo' => 'bar'
+                    ],
+                    '_meta' => [
+                        'author' => 'bar'
                     ]
                 ]
             ],
@@ -301,6 +313,9 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $documentContent = [
             'foo' => 'bar'
         ];
+        $documentMeta = [
+            'author' => 'foo'
+        ];
 
         $httpRequest = [
             'route' => '/' . $index . '/' . $collection . '/' . $documentId . '/_create',
@@ -320,6 +335,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $createDocumentResponse = [
             '_id' => $documentId,
             '_source' => $documentContent,
+            '_meta' => $documentMeta,
             '_version' => 1
         ];
         $httpResponse = [
@@ -363,6 +379,9 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $documentContent = [
             'foo' => 'bar'
         ];
+        $documentMeta = [
+            'author' => 'foo'
+        ];
 
         $httpRequest = [
             'route' => '/' . $index . '/' . $collection . '/' . $documentId,
@@ -375,13 +394,15 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                 'requestId' => $requestId,
                 'collection' => $collection,
                 'index' => $index,
-                '_id' => $documentId
+                '_id' => $documentId,
+                'meta' => $documentMeta
             ],
             'query_parameters' => []
         ];
         $createDocumentResponse = [
             '_id' => $documentId,
             '_source' => $documentContent,
+            '_meta' => $documentMeta,
             '_version' => 1
         ];
         $httpResponse = [
@@ -406,13 +427,14 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $documentObject = new \Kuzzle\Document($dataCollection, $documentId, $documentContent);
+        $documentObject = new \Kuzzle\Document($dataCollection, $documentId, $documentContent, $documentMeta);
 
         $document = $dataCollection->createDocument($documentObject, '', ['ifExist' => 'replace', 'requestId' => $requestId]);
 
         $this->assertInstanceOf('Kuzzle\Document', $document);
         $this->assertAttributeEquals($documentId, 'id', $document);
         $this->assertAttributeEquals($documentContent, 'content', $document);
+        $this->assertAttributeEquals($documentMeta, 'meta', $document);
         $this->assertAttributeEquals(1, 'version', $document);
     }
 
@@ -519,7 +541,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                 'requestId' => $requestId,
                 'collection' => $collection,
                 'index' => $index,
-                'body' => (object)$filters
+                'body' => ['query' => (object)$filters]
             ],
             'query_parameters' => []
         ];
@@ -565,6 +587,9 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $documentContent = [
             'foo' => 'bar'
         ];
+        $documentMeta = [
+            'author' => 'foo'
+        ];
 
         $httpRequest = [
             'route' => '/' . $index . '/' . $collection . '/' . $documentId,
@@ -583,6 +608,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $fetchDocumentResponse = [
             '_id' => $documentId,
             '_source' => $documentContent,
+            '_meta' => $documentMeta,
             '_version' => 1
         ];
         $httpResponse = [
@@ -661,6 +687,9 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                     '_id' => 'test',
                     '_source' => [
                         'foo' => 'bar'
+                    ],
+                    '_meta' => [
+                        'author' => 'foo'
                     ]
                 ]
             ],
@@ -673,6 +702,9 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                     '_id' => 'test1',
                     '_source' => [
                         'foo' => 'bar'
+                    ],
+                    '_meta' => [
+                        'author' => 'bar'
                     ]
                 ]
             ],
@@ -768,6 +800,9 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                     '_id' => 'test',
                     '_source' => [
                         'foo' => 'bar'
+                    ],
+                    '_meta' => [
+                        'author' => 'foo'
                     ]
                 ]
             ],
@@ -779,6 +814,9 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                     '_id' => 'test1',
                     '_source' => [
                         'foo' => 'bar'
+                    ],
+                    '_meta' => [
+                        'author' => 'bar'
                     ]
                 ]
             ],
@@ -889,8 +927,11 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $collection = 'collection';
 
         $documentId = uniqid();
-        $document = [
+        $documentContent = [
             'foo' => 'bar'
+        ];
+        $documentMeta = [
+            'author' => 'foo'
         ];
 
         $httpRequest = [
@@ -900,11 +941,12 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                 'volatile' => [],
                 'controller' => 'realtime',
                 'action' => 'publish',
-                'body' => $document,
+                'body' => $documentContent,
                 'requestId' => $requestId,
                 'collection' => $collection,
                 'index' => $index,
-                '_id' => $documentId
+                '_id' => $documentId,
+                'meta' => $documentMeta
             ],
             'query_parameters' => []
         ];
@@ -933,7 +975,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $documentObject = new \Kuzzle\Document($dataCollection, $documentId, $document);
+        $documentObject = new \Kuzzle\Document($dataCollection, $documentId, $documentContent, $documentMeta);
 
         $result = $dataCollection->publishMessage($documentObject, ['requestId' => $requestId]);
 
@@ -950,6 +992,9 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $documentId = uniqid();
         $documentContent = [
             'foo' => 'bar'
+        ];
+        $documentMeta = [
+            'author' => 'foo'
         ];
 
         $httpRequest = [
@@ -970,6 +1015,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $createDocumentResponse = [
             '_id' => $documentId,
             '_source' => $documentContent,
+            '_meta' => $documentMeta,
             '_version' => 1
         ];
         $httpResponse = [
@@ -999,6 +1045,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Kuzzle\Document', $document);
         $this->assertAttributeEquals($documentId, 'id', $document);
         $this->assertAttributeEquals($documentContent, 'content', $document);
+        $this->assertAttributeEquals($documentMeta, 'meta', $document);
         $this->assertAttributeEquals(1, 'version', $document);
     }
 
@@ -1065,6 +1112,9 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $documentContent = [
             'foo' => 'bar'
         ];
+        $documentMeta = [
+            'author' => 'foo'
+        ];
 
         $kuzzle = $this
             ->getMockBuilder('\Kuzzle\Kuzzle')
@@ -1116,6 +1166,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $getResponse = [
             '_id' => $documentId,
             '_source' => $documentContent,
+            '_meta' => $documentMeta,
             '_version' => 2
         ];
         $httpGetResponse = [
@@ -1145,6 +1196,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Kuzzle\Document', $document);
         $this->assertAttributeEquals($documentId, 'id', $document);
         $this->assertAttributeEquals($documentContent, 'content', $document);
+        $this->assertAttributeEquals($documentMeta, 'meta', $document);
         $this->assertAttributeEquals(2, 'version', $document);
     }
 }

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -113,7 +113,8 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
                 'collection' => $collection,
                 'index' => $index,
                 '_id' => $documentId,
-                'body' => $documentContent
+                'body' => $documentContent,
+                'meta' => null
             ],
             'query_parameters' => []
         ];

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -17,6 +17,9 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $documentContent = [
             'foo' => 'bar'
         ];
+        $documentMeta = [
+            'author' => 'foo'
+        ];
 
         $httpRequest = [
             'route' => '/' . $index . '/' . $collection . '/' . $documentId,
@@ -29,7 +32,8 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
                 'collection' => $collection,
                 'index' => $index,
                 '_id' => $documentId,
-                'body' => $documentContent
+                'body' => $documentContent,
+                'meta' => $documentMeta
             ],
             'query_parameters' => []
         ];
@@ -57,7 +61,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
          * @var Kuzzle $kuzzle
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
-        $document = new Document($dataCollection, $documentId, $documentContent);
+        $document = new Document($dataCollection, $documentId, $documentContent, $documentMeta);
 
         $result = $document->delete(['requestId' => $requestId]);
 
@@ -119,6 +123,9 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $documentContent = [
             'foo' => 'bar'
         ];
+        $documentMeta = [
+            'author' => 'foo'
+        ];
 
         $httpRequest = [
             'route' => '/' . $index . '/' . $collection . '/' . $documentId,
@@ -131,13 +138,15 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
                 'collection' => $collection,
                 'index' => $index,
                 '_id' => $documentId,
-                'body' => array_merge($documentContent, ['baz' => 'baz'])
+                'body' => array_merge($documentContent, ['baz' => 'baz']),
+                'meta' => array_merge($documentMeta, ['author' => 'bar']),
             ],
             'query_parameters' => []
         ];
         $saveResponse = [
             '_id' => $documentId,
             '_source' => $documentContent,
+            '_meta' => $documentMeta,
             '_version' => 1
         ];
         $httpResponse = [
@@ -161,14 +170,16 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
          * @var Kuzzle $kuzzle
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
-        $document = new Document($dataCollection, $documentId, $documentContent);
+        $document = new Document($dataCollection, $documentId, $documentContent, $documentMeta);
 
         $document->setContent(['baz' => 'baz']);
+        $document->setMeta(['author' => 'bar']);
         $result = $document->save(['requestId' => $requestId]);
 
         $this->assertInstanceOf('Kuzzle\Document', $result);
         $this->assertAttributeEquals($documentId, 'id', $result);
         $this->assertAttributeEquals(array_merge($documentContent, ['baz' => 'baz']), 'content', $result);
+        $this->assertAttributeEquals(array_merge($documentMeta, ['author' => 'bar']), 'meta', $result);
         $this->assertAttributeEquals(1, 'version', $result);
     }
 
@@ -183,6 +194,9 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $documentContent = [
             'foo' => 'bar'
         ];
+        $documentMeta = [
+            'author' => 'foo'
+        ];
 
         $httpRequest = [
             'route' => '/' . $index . '/' . $collection . '/_publish',
@@ -195,7 +209,8 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
                 'collection' => $collection,
                 'index' => $index,
                 '_id' => $documentId,
-                'body' => array_merge($documentContent, ['baz' => 'baz'])
+                'body' => array_merge($documentContent, ['baz' => 'baz']),
+                'meta' => array_merge($documentMeta, ['author' => 'bar'])
             ],
             'query_parameters' => []
         ];
@@ -223,14 +238,16 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
          * @var Kuzzle $kuzzle
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
-        $document = new Document($dataCollection, $documentId, $documentContent);
+        $document = new Document($dataCollection, $documentId, $documentContent, $documentMeta);
 
         $document->setContent(['baz' => 'baz']);
+        $document->setMeta(['author' => 'bar']);
         $result = $document->publish(['requestId' => $requestId]);
 
         $this->assertInstanceOf('Kuzzle\Document', $result);
         $this->assertAttributeEquals($documentId, 'id', $result);
         $this->assertAttributeEquals(array_merge($documentContent, ['baz' => 'baz']), 'content', $result);
+        $this->assertAttributeEquals(array_merge($documentMeta, ['author' => 'bar']), 'meta', $result);
     }
 
     function testSerialize()
@@ -243,16 +260,20 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $documentContent = [
             'foo' => 'bar'
         ];
+        $documentMeta = [
+            'author' => 'foo'
+        ];
 
         $kuzzle = new \Kuzzle\Kuzzle($url);
         $dataCollection = new Collection($kuzzle, $collection, $index);
-        $document = $dataCollection->document($documentId, array_merge($documentContent, ['_version' => 1]));
+        $document = $dataCollection->document($documentId, array_merge($documentContent, ['_version' => 1]), $documentMeta);
 
         $result = $document->serialize();
 
         $this->assertEquals([
             '_id' => $documentId,
             'body' => $documentContent,
+            'meta' => $documentMeta,
             '_version' => 1,
         ], $result);
     }


### PR DESCRIPTION
# Introduces

- Meta in Document objects
- Fix for the deleteByQuery route (related to https://github.com/kuzzleio/kuzzle-sdk/issues/4)
- Updates to the `examples/document.php` file, not aligned with new syntax