### PR TITLE
Add support for Document:m* methods

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -341,6 +341,164 @@ class Collection
     }
 
     /**
+     * Create the provided documents
+     *
+     * @param array $documents Array of documents to create
+     * @param array $options Optional parameters
+     * @return mixed
+     */
+    public function mCreate($documents, array $options = [])
+    {
+        if (!is_array($documents)) {
+            throw new InvalidArgumentException('Collection.mCreate: documents parameter format is invalid (should be an array of documents)');
+        }
+
+        $documents = array_map(function ($document) {
+            return $document instanceof Document ? $document->serialize() : $document;
+        }, $documents);
+
+        $data = ['body' => ['documents' => $documents]];
+
+        $response = $this->kuzzle->query(
+            $this->buildQueryArgs('document', 'mCreate'),
+            $this->kuzzle->addHeaders($data, $this->headers),
+            $options
+        );
+
+        return $response['result'];
+    }
+
+    /**
+     * Create or replace the provided documents
+     *
+     * @param array $documents Array of documents to create or replace
+     * @param array $options Optional parameters
+     * @return mixed
+     */
+    public function mCreateOrReplace($documents, array $options = [])
+    {
+        if (!is_array($documents)) {
+            throw new InvalidArgumentException('Collection.mCreateOrReplace: documents parameter format is invalid (should be an array of documents)');
+        }
+
+        $documents = array_map(function ($document) {
+            return $document instanceof Document ? $document->serialize() : $document;
+        }, $documents);
+
+        $data = ['body' => ['documents' => $documents]];
+
+        $response = $this->kuzzle->query(
+            $this->buildQueryArgs('document', 'mCreateOrReplace'),
+            $this->kuzzle->addHeaders($data, $this->headers),
+            $options
+        );
+
+        return $response['result'];
+    }
+
+    /**
+     * Delete specific documents according to given IDs
+     *
+     * @param array $documentIds IDs of the documents to delete
+     * @param array $options Optional parameters
+     * @return mixed
+     */
+    public function mDelete($documentIds, array $options = [])
+    {
+        if (!is_array($documentIds)) {
+            throw new InvalidArgumentException('Collection.mDelete: documents parameter format is invalid (should be an array of document IDs)');
+        }
+
+        $data = ['body' => ['ids' => $documentIds]];
+
+        $response = $this->kuzzle->query(
+            $this->buildQueryArgs('document', 'mDelete'),
+            $this->kuzzle->addHeaders($data, $this->headers),
+            $options
+        );
+
+        return $response['result'];
+    }
+
+    /**
+     * Get specific documents according to given IDs
+     *
+     * @param array $documentIds IDs of the documents to retrieve
+     * @param array $options Optional parameters
+     * @return mixed
+     */
+    public function mGet($documentIds, array $options = [])
+    {
+        if (!is_array($documentIds)) {
+            throw new InvalidArgumentException('Collection.mGet: documents parameter format is invalid (should be an array of document IDs)');
+        }
+
+        $data = ['body' => ['ids' => $documentIds]];
+
+        $response = $this->kuzzle->query(
+            $this->buildQueryArgs('document', 'mGet'),
+            $this->kuzzle->addHeaders($data, $this->headers),
+            $options
+        );
+
+        return $response['result'];
+    }
+
+    /**
+     * Replace the provided documents
+     *
+     * @param array $documents Array of documents to replace
+     * @param array $options Optional parameters
+     */
+    public function mReplace($documents, array $options = [])
+    {
+        if (!is_array($documents)) {
+            throw new InvalidArgumentException('Collection.mReplace: documents parameter format is invalid (should be an array of documents)');
+        }
+
+        $documents = array_map(function ($document) {
+            return $document instanceof Document ? $document->serialize() : $document;
+        }, $documents);
+
+        $data = ['body' => ['documents' => $documents]];
+
+        $response = $this->kuzzle->query(
+            $this->buildQueryArgs('document', 'mReplace'),
+            $this->kuzzle->addHeaders($data, $this->headers),
+            $options
+        );
+
+        return $response['result'];
+    }
+
+    /**
+     * Update the provided documents
+     *
+     * @param array $documents Array of documents to update
+     * @param array $options Optional parameters
+     */
+    public function mUpdate($documents, array $options = [])
+    {
+        if (!is_array($documents)) {
+            throw new InvalidArgumentException('Collection.mUpdate: documents parameter format is invalid (should be an array of documents)');
+        }
+
+        $documents = array_map(function ($document) {
+            return $document instanceof Document ? $document->serialize() : $document;
+        }, $documents);
+
+        $data = ['body' => ['documents' => $documents]];
+
+        $response = $this->kuzzle->query(
+            $this->buildQueryArgs('document', 'mUpdate'),
+            $this->kuzzle->addHeaders($data, $this->headers),
+            $options
+        );
+
+        return $response['result'];
+    }
+
+    /**
      * Create a new document in Kuzzle.
      *
      * @param array|Document $document either an instance of a KuzzleDocument object, or a document

--- a/src/config/routes.json
+++ b/src/config/routes.json
@@ -93,6 +93,36 @@
       "name": "create",
       "route": "/:index/:collection",
       "method": "put"
+    },
+    "mCreate": {
+      "name": "mCreate",
+      "route": "/:index/:collection/_mCreate",
+      "method": "post"
+    },
+    "mCreateOrReplace": {
+      "name": "mCreateOrReplace",
+      "route": "/:index/:collection/_mCreateOrReplace",
+      "method": "put"
+    },
+    "mDelete": {
+      "name": "mDelete",
+      "route": "/:index/:collection/_mDelete",
+      "method": "delete"
+    },
+    "mGet": {
+      "name": "mGet",
+      "route": "/:index/:collection/_mGet",
+      "method": "post"
+    },
+    "mReplace": {
+      "name": "mReplace",
+      "route": "/:index/:collection/_mReplace",
+      "method": "put"
+    },
+    "mUpdate": {
+      "name": "mUpdate",
+      "route": "/:index/:collection/_mUpdate",
+      "method": "put"
     }
   },
   "document": {

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -826,6 +826,366 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals('test1', 'id', $documents[1]);
     }
 
+    function testMCreate()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $documents = [
+            'documents' => [
+                ['_id' => 'foo1', 'foo' => 'bar'],
+                ['_id' => 'foo2', 'foo' => 'bar'],
+            ]
+        ];
+
+        $httpRequest = [
+            'route' => '/' . $index . '/' . $collection . '/_mCreate',
+            'method' => 'POST',
+            'request' => [
+                'volatile' => [],
+                'controller' => 'document',
+                'action' => 'mCreate',
+                'body' => $documents,
+                'requestId' => $requestId,
+                'collection' => $collection,
+                'index' => $index
+            ],
+            'query_parameters' => []
+        ];
+        $mCreateResponse = [
+            '_source' => [
+                'hits' => $documents['documents'],
+                'total' => count($documents['documents'])
+            ]
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $mCreateResponse
+        ];
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        /**
+         * @var Kuzzle $kuzzle
+         */
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $result = $dataCollection->mCreate($documents['documents'], ['requestId' => $requestId]);
+
+        $this->assertEquals($httpResponse['result'], $result);
+    }
+
+    function testMCreateOrReplace()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $documents = [
+            'documents' => [
+                ['_id' => 'foo1', 'foo' => 'bar'],
+                ['_id' => 'foo2', 'foo' => 'bar'],
+            ]
+        ];
+
+        $httpRequest = [
+            'route' => '/' . $index . '/' . $collection . '/_mCreateOrReplace',
+            'method' => 'PUT',
+            'request' => [
+                'volatile' => [],
+                'controller' => 'document',
+                'action' => 'mCreateOrReplace',
+                'body' => $documents,
+                'requestId' => $requestId,
+                'collection' => $collection,
+                'index' => $index
+            ],
+            'query_parameters' => []
+        ];
+        $mCreateOrReplaceResponse = [
+            '_source' => [
+                'hits' => $documents['documents'],
+                'total' => count($documents['documents'])
+            ]
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $mCreateOrReplaceResponse
+        ];
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        /**
+         * @var Kuzzle $kuzzle
+         */
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $result = $dataCollection->mCreateOrReplace($documents['documents'], ['requestId' => $requestId]);
+
+        $this->assertEquals($httpResponse['result'], $result);
+    }
+
+    function testMDelete()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $documentIds = [
+            'ids' => ['foo1', 'foo2']
+        ];
+
+        $httpRequest = [
+            'route' => '/' . $index . '/' . $collection . '/_mDelete',
+            'method' => 'DELETE',
+            'request' => [
+                'volatile' => [],
+                'controller' => 'document',
+                'action' => 'mDelete',
+                'body' => $documentIds,
+                'requestId' => $requestId,
+                'collection' => $collection,
+                'index' => $index
+            ],
+            'query_parameters' => []
+        ];
+        $mDeleteResponse = [
+            '_source' => [
+                'hits' => $documentIds['ids'],
+                'total' => count($documentIds['ids'])
+            ]
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $mDeleteResponse
+        ];
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        /**
+         * @var Kuzzle $kuzzle
+         */
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $result = $dataCollection->mDelete($documentIds['ids'], ['requestId' => $requestId]);
+
+        $this->assertEquals($httpResponse['result'], $result);
+    }
+
+    function testMGet()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $documentIds = [
+            'ids' => ['foo1', 'foo2']
+        ];
+
+        $httpRequest = [
+            'route' => '/' . $index . '/' . $collection . '/_mGet',
+            'method' => 'POST',
+            'request' => [
+                'volatile' => [],
+                'controller' => 'document',
+                'action' => 'mGet',
+                'body' => $documentIds,
+                'requestId' => $requestId,
+                'collection' => $collection,
+                'index' => $index
+            ],
+            'query_parameters' => []
+        ];
+        $mGetResponse = [
+            '_source' => [
+                'hits' => $documentIds['ids'],
+                'total' => count($documentIds['ids'])
+            ]
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $mGetResponse
+        ];
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        /**
+         * @var Kuzzle $kuzzle
+         */
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $result = $dataCollection->mGet($documentIds['ids'], ['requestId' => $requestId]);
+
+        $this->assertEquals($httpResponse['result'], $result);
+    }
+
+    function testMReplace()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $documents = [
+            'documents' => [
+                ['_id' => 'foo1', 'foo' => 'bar'],
+                ['_id' => 'foo2', 'foo' => 'bar'],
+            ]
+        ];
+
+        $httpRequest = [
+            'route' => '/' . $index . '/' . $collection . '/_mReplace',
+            'method' => 'PUT',
+            'request' => [
+                'volatile' => [],
+                'controller' => 'document',
+                'action' => 'mReplace',
+                'body' => $documents,
+                'requestId' => $requestId,
+                'collection' => $collection,
+                'index' => $index
+            ],
+            'query_parameters' => []
+        ];
+        $mReplaceResponse = [
+            '_source' => [
+                'hits' => $documents['documents'],
+                'total' => count($documents['documents'])
+            ]
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $mReplaceResponse
+        ];
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        /**
+         * @var Kuzzle $kuzzle
+         */
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $result = $dataCollection->mReplace($documents['documents'], ['requestId' => $requestId]);
+
+        $this->assertEquals($httpResponse['result'], $result);
+    }
+
+    function testMUpdate()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $documents = [
+            'documents' => [
+                ['_id' => 'foo1', 'foo' => 'bar'],
+                ['_id' => 'foo2', 'foo' => 'bar'],
+            ]
+        ];
+
+        $httpRequest = [
+            'route' => '/' . $index . '/' . $collection . '/_mUpdate',
+            'method' => 'PUT',
+            'request' => [
+                'volatile' => [],
+                'controller' => 'document',
+                'action' => 'mUpdate',
+                'body' => $documents,
+                'requestId' => $requestId,
+                'collection' => $collection,
+                'index' => $index
+            ],
+            'query_parameters' => []
+        ];
+        $mUpdateResponse = [
+            '_source' => [
+                'hits' => $documents['documents'],
+                'total' => count($documents['documents'])
+            ]
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $mUpdateResponse
+        ];
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        /**
+         * @var Kuzzle $kuzzle
+         */
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $result = $dataCollection->mUpdate($documents['documents'], ['requestId' => $requestId]);
+
+        $this->assertEquals($httpResponse['result'], $result);
+    }
+
     function testPublishDocument()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;


### PR DESCRIPTION
# Introduces
- Document;m* methods support (related to https://github.com/kuzzleio/kuzzle/pull/616)
- Corresponding unit tests

fix https://github.com/kuzzleio/kuzzle-sdk/issues/6