### PR TITLE
Renamed m* methods

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -347,10 +347,10 @@ class Collection
      * @param array $options Optional parameters
      * @return mixed
      */
-    public function mCreate($documents, array $options = [])
+    public function mCreateDocument($documents, array $options = [])
     {
         if (!is_array($documents)) {
-            throw new InvalidArgumentException('Collection.mCreate: documents parameter format is invalid (should be an array of documents)');
+            throw new InvalidArgumentException('Collection.mCreateDocument: documents parameter format is invalid (should be an array of documents)');
         }
 
         $documents = array_map(function ($document) {
@@ -375,10 +375,10 @@ class Collection
      * @param array $options Optional parameters
      * @return mixed
      */
-    public function mCreateOrReplace($documents, array $options = [])
+    public function mCreateOrReplaceDocument($documents, array $options = [])
     {
         if (!is_array($documents)) {
-            throw new InvalidArgumentException('Collection.mCreateOrReplace: documents parameter format is invalid (should be an array of documents)');
+            throw new InvalidArgumentException('Collection.mCreateOrReplaceDocument: documents parameter format is invalid (should be an array of documents)');
         }
 
         $documents = array_map(function ($document) {
@@ -403,10 +403,10 @@ class Collection
      * @param array $options Optional parameters
      * @return mixed
      */
-    public function mDelete($documentIds, array $options = [])
+    public function mDeleteDocument($documentIds, array $options = [])
     {
         if (!is_array($documentIds)) {
-            throw new InvalidArgumentException('Collection.mDelete: documents parameter format is invalid (should be an array of document IDs)');
+            throw new InvalidArgumentException('Collection.mDeleteDocument: documents parameter format is invalid (should be an array of document IDs)');
         }
 
         $data = ['body' => ['ids' => $documentIds]];
@@ -427,10 +427,10 @@ class Collection
      * @param array $options Optional parameters
      * @return mixed
      */
-    public function mGet($documentIds, array $options = [])
+    public function mGetDocument($documentIds, array $options = [])
     {
         if (!is_array($documentIds)) {
-            throw new InvalidArgumentException('Collection.mGet: documents parameter format is invalid (should be an array of document IDs)');
+            throw new InvalidArgumentException('Collection.mGetDocument: documents parameter format is invalid (should be an array of document IDs)');
         }
 
         $data = ['body' => ['ids' => $documentIds]];
@@ -450,10 +450,10 @@ class Collection
      * @param array $documents Array of documents to replace
      * @param array $options Optional parameters
      */
-    public function mReplace($documents, array $options = [])
+    public function mReplaceDocument($documents, array $options = [])
     {
         if (!is_array($documents)) {
-            throw new InvalidArgumentException('Collection.mReplace: documents parameter format is invalid (should be an array of documents)');
+            throw new InvalidArgumentException('Collection.mReplaceDocument: documents parameter format is invalid (should be an array of documents)');
         }
 
         $documents = array_map(function ($document) {
@@ -477,10 +477,10 @@ class Collection
      * @param array $documents Array of documents to update
      * @param array $options Optional parameters
      */
-    public function mUpdate($documents, array $options = [])
+    public function mUpdateDocument($documents, array $options = [])
     {
         if (!is_array($documents)) {
-            throw new InvalidArgumentException('Collection.mUpdate: documents parameter format is invalid (should be an array of documents)');
+            throw new InvalidArgumentException('Collection.mUpdateDocument: documents parameter format is invalid (should be an array of documents)');
         }
 
         $documents = array_map(function ($document) {

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -826,7 +826,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals('test1', 'id', $documents[1]);
     }
 
-    function testMCreate()
+    function testMCreateDocument()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;
         $requestId = uniqid();
@@ -882,12 +882,12 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $result = $dataCollection->mCreate($documents['documents'], ['requestId' => $requestId]);
+        $result = $dataCollection->mCreateDocument($documents['documents'], ['requestId' => $requestId]);
 
         $this->assertEquals($httpResponse['result'], $result);
     }
 
-    function testMCreateOrReplace()
+    function testMCreateOrReplaceDocument()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;
         $requestId = uniqid();
@@ -943,12 +943,12 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $result = $dataCollection->mCreateOrReplace($documents['documents'], ['requestId' => $requestId]);
+        $result = $dataCollection->mCreateOrReplaceDocument($documents['documents'], ['requestId' => $requestId]);
 
         $this->assertEquals($httpResponse['result'], $result);
     }
 
-    function testMDelete()
+    function testMDeleteDocument()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;
         $requestId = uniqid();
@@ -1001,12 +1001,12 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $result = $dataCollection->mDelete($documentIds['ids'], ['requestId' => $requestId]);
+        $result = $dataCollection->mDeleteDocument($documentIds['ids'], ['requestId' => $requestId]);
 
         $this->assertEquals($httpResponse['result'], $result);
     }
 
-    function testMGet()
+    function testMGetDocument()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;
         $requestId = uniqid();
@@ -1059,12 +1059,12 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $result = $dataCollection->mGet($documentIds['ids'], ['requestId' => $requestId]);
+        $result = $dataCollection->mGetDocument($documentIds['ids'], ['requestId' => $requestId]);
 
         $this->assertEquals($httpResponse['result'], $result);
     }
 
-    function testMReplace()
+    function testMReplaceDocument()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;
         $requestId = uniqid();
@@ -1120,12 +1120,12 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $result = $dataCollection->mReplace($documents['documents'], ['requestId' => $requestId]);
+        $result = $dataCollection->mReplaceDocument($documents['documents'], ['requestId' => $requestId]);
 
         $this->assertEquals($httpResponse['result'], $result);
     }
 
-    function testMUpdate()
+    function testMUpdateDocument()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;
         $requestId = uniqid();
@@ -1181,7 +1181,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $result = $dataCollection->mUpdate($documents['documents'], ['requestId' => $requestId]);
+        $result = $dataCollection->mUpdateDocument($documents['documents'], ['requestId' => $requestId]);
 
         $this->assertEquals($httpResponse['result'], $result);
     }


### PR DESCRIPTION
Small PR to rename m* methods to avoid confusion with other methods of the Collection class.

Also used to align with the other SDKs.