### PR TITLE
Add a getProfileIds method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 Official Kuzzle PHP SDK
 ======
 
-This SDK version is compatible with Kuzzle 1.0.0-RC10 and higher
-
 ## About Kuzzle
 
 A backend software, self-hostable and ready to use to power modern apps.
@@ -19,7 +17,7 @@ You can access the Kuzzle repository on [Github](https://github.com/kuzzleio/kuz
 
 ## SDK Documentation
 
-The complete SDK documentation is available [here](http://kuzzle.io/sdk-documentation/?php)
+The complete SDK documentation is available [here](http://docs.kuzzle.io/sdk-reference/)
 
 ## Report an issue
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Official Kuzzle PHP SDK
 ======
 
-This SDK version is compatible with Kuzzle 1.0.0-RC9.5 and higher
+This SDK version is compatible with Kuzzle 1.0.0-RC10 and higher
 
 ## About Kuzzle
 
-For UI and linked objects developers, Kuzzle is an open-source solution that handles all the data management (CRUD, real-time storage, search, high-level features, etc).
+A backend software, self-hostable and ready to use to power modern apps.
 
 You can access the Kuzzle repository on [Github](https://github.com/kuzzleio/kuzzle)
 

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -38,9 +38,9 @@ class User extends Document
     }
 
     /**
-     * Returns this user associated profile.
+     * Returns this user associated profiles.
      *
-     * @return Profile[]|false
+     * @return Profile[]
      */
     public function getProfiles()
     {
@@ -55,6 +55,19 @@ class User extends Document
         }
 
         return $profiles;
+    }
+
+    /**
+     * Returns this user associated profile identifiers
+     * @return  string[]
+     */
+    public function getProfileIds()
+    {
+        if (!array_key_exists('profileIds', $this->content)) {
+            return [];
+        }
+
+        return $this->content['profileIds'];
     }
 
     /**

--- a/tests/Security/UserTest.php
+++ b/tests/Security/UserTest.php
@@ -23,6 +23,69 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($user->getProfiles(), []);
     }
 
+    function testGetProfiles()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $stubSecurity = $this
+            ->getMockBuilder(Security::class)
+            ->setConstructorArgs([$kuzzle])
+            ->getMock();
+        $stubSecurity->method('fetchProfile')->willReturn(new Profile($stubSecurity, 'foo', []));
+
+        $user = new User($stubSecurity, 'foobar', [
+            'profileIds' => ['foo', 'bar', 'baz']
+        ]);
+
+        $profiles = $user->getProfiles();
+        $this->assertEquals(3, count($profiles));
+
+        foreach($profiles as $profile) {
+            $this->assertInstanceOf(Profile::class, $profile);
+            $this->assertEquals('foo', $profile->getId());
+        }
+    }
+
+    function testEmptyGetProfileIds()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $security = new Security($kuzzle);
+        $user = new User($security, '', []);
+
+        $this->assertEquals($user->getProfileIds(), []);
+    }
+
+    function testGetProfileIds()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $security = new Security($kuzzle);
+        $user = new User($security, 'foobar', [
+            'profileIds' => ['foo', 'bar', 'baz']
+        ]);
+
+        $this->assertEquals($user->getProfileIds(), ['foo', 'bar', 'baz']);
+    }
+
     function testAddProfile()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;

--- a/tests/Security/UserTest.php
+++ b/tests/Security/UserTest.php
@@ -34,7 +34,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $stubSecurity = $this
-            ->getMockBuilder(Security::class)
+            ->getMockBuilder('Kuzzle\Security\Security')
             ->setConstructorArgs([$kuzzle])
             ->getMock();
         $stubSecurity->method('fetchProfile')->willReturn(new Profile($stubSecurity, 'foo', []));
@@ -47,7 +47,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, count($profiles));
 
         foreach($profiles as $profile) {
-            $this->assertInstanceOf(Profile::class, $profile);
+            $this->assertInstanceOf('Kuzzle\Security\Profile', $profile);
             $this->assertEquals('foo', $profile->getId());
         }
     }


### PR DESCRIPTION
# Description

Add a new `User.getProfileIds` method returning the list of profile IDs, the advantage being that no Kuzzle API calls are made with this method

# Boyscout

* Add missing unit tests on `User.getProfiles`
* Update Kuzzle description and documentation URLs in the README file

# Related issue

https://github.com/kuzzleio/kuzzle-sdk/issues/33
