### PR TITLE
Allow paginated search using ES's search_after in SearchResult:fetchNext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/kuzzleio/sdk-php.svg?branch=master)](https://travis-ci.org/kuzzleio/sdk-php) [![codecov.io](http://codecov.io/github/kuzzleio/sdk-php/coverage.svg?branch=master)](http://codecov.io/github/kuzzleio/sdk-php?branch=master)
+
 Official Kuzzle PHP SDK
 ======
 
@@ -10,6 +12,7 @@ You can access the Kuzzle repository on [Github](https://github.com/kuzzleio/kuz
 * [SDK Documentation](#sdk-documentation)
 * [Report an issue](#report-an-issue)
 * [Installation](#installation)
+* [Basic usage](#basic-usage)
 * [Running tests](#tests)
 * [License](#license)
 
@@ -29,6 +32,30 @@ This SDK can be used in any project using composer:
 
 ```
 composer require kuzzleio/kuzzle-sdk
+```
+
+## Basic usage
+
+```php
+<?php
+
+use \Kuzzle\Kuzzle;
+use \Kuzzle\Document;
+
+$kuzzle = new Kuzzle('localhost');
+$collection = $kuzzle->collection('bar', 'foo');
+
+$firstDocument = new Document($collection, 'john', ['name' => 'John', 'age' => 42]);
+$secondDocument = new Document($collection, 'michael', ['name' => 'Michael', 'age' => 36]);
+
+$firstDocument->save(['refresh' => 'wait_for']);
+$secondDocument->save(['refresh' => 'wait_for']);
+
+$result = $collection->search(['sort' => [['age' => 'asc']]]);
+foreach ($result->getDocuments() as $document) {
+    $content = $document->getContent();
+    echo "Name: {$content['name']}, age: {$content['age']}\n";
+}
 ```
 
 ## <a name="tests"></a> Running Tests

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -640,8 +640,8 @@ class Collection
     }
 
     /**
-     * @param $controller
-     * @param $action
+     * @param string $controller
+     * @param string $action
      * @return array
      */
     public function buildQueryArgs($controller, $action)

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -78,7 +78,6 @@ class Kuzzle
      */
     protected $requestHandler;
 
-
     /**
      * Kuzzle constructor.
      *
@@ -108,7 +107,6 @@ class Kuzzle
             $this->port = $options['port'];
         }
 
-
         $this->url = 'http://' . $host . ':' . $this->port;
         $this->loadRoutesDescription($this->routesDescriptionFile);
 
@@ -121,7 +119,7 @@ class Kuzzle
      *
      * @param string $event One of the event described in the Event Handling section of the kuzzle documentation
      * @param callable $listener The function to call each time one of the registered event is fired
-     *
+     * @return $this
      * @throws InvalidArgumentException
      */
     public function addListener($event, $listener)
@@ -143,7 +141,7 @@ class Kuzzle
      * Emit an event to all registered listeners
      *
      * @param string $event One of the event described in the Event Handling section of the kuzzle documentation
-     *
+     * @return $this
      */
     public function emitEvent($event)
     {
@@ -562,17 +560,10 @@ class Kuzzle
                 $httpParams['query_parameters'] = array_merge($httpParams['query_parameters'], $options['query_parameters']);
             }
 
-            if (array_key_exists('refresh', $options)) {
-                $httpParams['query_parameters']['refresh'] = $options['refresh'];
-            }
-            if (array_key_exists('from', $options)) {
-                $httpParams['query_parameters']['from'] = $options['from'];
-            }
-            if (array_key_exists('size', $options)) {
-                $httpParams['query_parameters']['size'] = $options['size'];
-            }
-            if (array_key_exists('scroll', $options)) {
-                $httpParams['query_parameters']['scroll'] = $options['scroll'];
+            foreach (['refresh', 'from', 'size', 'scroll'] as $optionParam) {
+                if (array_key_exists($optionParam, $options)) {
+                    $httpParams['query_parameters'][$optionParam] = $options[$optionParam];
+                }
             }
         }
 
@@ -604,20 +595,10 @@ class Kuzzle
             $request['headers']['authorization'] = 'Bearer ' . $this->jwtToken;
         }
 
-        if (array_key_exists('collection', $queryArgs)) {
-            $request['collection'] = $queryArgs['collection'];
-        }
-
-        if (array_key_exists('route', $queryArgs)) {
-            $request['route'] = $queryArgs['route'];
-        }
-
-        if (array_key_exists('method', $queryArgs)) {
-            $request['method'] = $queryArgs['method'];
-        }
-
-        if (array_key_exists('index', $queryArgs)) {
-            $request['index'] = $queryArgs['index'];
+        foreach (['collection', 'route', 'method', 'index'] as $queryArg) {
+            if (array_key_exists($queryArg, $queryArgs)) {
+                $request[$queryArg] = $queryArgs[$queryArg];
+            }
         }
 
         if (!array_key_exists('requestId', $request)) {

--- a/src/Util/SearchResult.php
+++ b/src/Util/SearchResult.php
@@ -135,21 +135,7 @@ class SearchResult
     {
         $searchResult = null;
 
-        if (array_key_exists('size', $this->options)
-            && array_key_exists('sort', $this->filters)
-            && !array_key_exists('from', $this->options)) {
-            // retrieve next results using ES's search_after
-            if ($this->fetchedDocuments >= $this->getTotal()) {
-                return null;
-            }
-
-            $filters = $this->filters;
-            $filters['search_after'] = array_map(function ($sortRule) {
-                return end($this->documents)->getContent()[key($sortRule)];
-            }, $this->filters['sort']);
-
-            $searchResult = $this->collection->search($filters, $this->options);
-        } else if (array_key_exists('scrollId', $this->options)) {
+        if (array_key_exists('scrollId', $this->options)) {
             // retrieve next results with scroll if original search use it
             if ($this->fetchedDocuments >= $this->getTotal()) {
                 return null;
@@ -171,6 +157,21 @@ class SearchResult
                 $options,
                 $this->filters
             );
+        } else if (array_key_exists('size', $this->options) && array_key_exists('sort', $this->filters)) {
+            // retrieve next results using ES's search_after
+            if ($this->fetchedDocuments >= $this->getTotal()) {
+                return null;
+            }
+
+            $options = $this->options;
+            unset($options['from']);
+
+            $filters = $this->filters;
+            $filters['search_after'] = array_map(function ($sortRule) {
+                return end($this->documents)->getContent()[key($sortRule)];
+            }, $this->filters['sort']);
+
+            $searchResult = $this->collection->search($filters, $options);
         } else if (array_key_exists('from', $this->options) && array_key_exists('size', $this->options)) {
             // retrieve next results with  from/size if original search use it
             $filters = $this->filters;

--- a/tests/SearchResultTest.php
+++ b/tests/SearchResultTest.php
@@ -1,0 +1,291 @@
+<?php
+
+use Kuzzle\Document;
+use Kuzzle\Collection;
+use Kuzzle\Util\SearchResult;
+
+class SearchResultTestTest extends \PHPUnit_Framework_TestCase
+{
+    function testSearchResultMethods()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $index = 'index';
+        $collection = 'collection';
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $firstDocumentId = uniqid();
+        $firstDocumentContent = [
+            'name' => 'John',
+            'age' => 42
+        ];
+
+        $secondDocumentId = uniqid();
+        $secondDocumentContent = [
+            'name' => 'Michael',
+            'age' => 36
+        ];
+
+        $documents = [
+            new Document($dataCollection, $firstDocumentId, $firstDocumentContent),
+            new Document($dataCollection, $secondDocumentId, $secondDocumentContent)
+        ];
+
+        $options = ['from' => 0, 'size' => 1];
+        $filters = ['sort' => [['age' => 'desc']]];
+
+        $searchResult = new SearchResult($dataCollection, 42, $documents, [], $options, $filters);
+
+        $this->assertEquals($searchResult->getTotal(), 42);
+        $this->assertEquals($searchResult->getDocuments(), $documents);
+        $this->assertEquals($searchResult->getOptions(), $options);
+        $this->assertEquals($searchResult->getFilters(), $filters);
+        $this->assertEquals($searchResult->getCollection(), $dataCollection);
+        $this->assertEquals($searchResult->getFetchedDocuments(), 2);
+    }
+
+    function testFetchNextWithSearchAfter()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $firstDocumentId = uniqid();
+        $firstDocumentContent = [
+            'name' => 'John',
+            'age' => 42
+        ];
+
+        $secondDocumentId = uniqid();
+        $secondDocumentContent = [
+            'name' => 'Michael',
+            'age' => 36
+        ];
+
+        $firstDocument = new Document($dataCollection, $firstDocumentId, $firstDocumentContent);
+        $secondDocument = new Document($dataCollection, $secondDocumentId, $secondDocumentContent);
+
+        $documents = [$firstDocument];
+
+        $httpRequest = [
+            'route' => '/' . $index . '/' . $collection . '/_search',
+            'method' => 'POST',
+            'request' => [
+                'volatile' => [],
+                'controller' => 'document',
+                'action' => 'search',
+                'requestId' => $requestId,
+                'collection' => $collection,
+                'index' => $index,
+                'body' => ['sort' => [['age' => 'desc']], 'search_after' => [42]]
+            ],
+            'query_parameters' => ['size' => 1]
+        ];
+
+        $searchResponse = [
+            'hits' => [
+                0 => [
+                    '_id' => $secondDocumentId,
+                    '_source' => $secondDocumentContent,
+                    '_meta' => []
+                ]
+            ],
+            'total' => 42
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $searchResponse
+        ];
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        $options = ['size' => 1, 'requestId' => $requestId];
+        $filters = ['sort' => [['age' => 'desc']]];
+
+        $initialSearchResult = new SearchResult($dataCollection, 42, $documents, [], $options, $filters);
+
+        $result = $initialSearchResult->fetchNext();
+
+        $secondSearchResult = new SearchResult($dataCollection, 42, [$secondDocument], [], $options, $filters);
+
+        $this->assertEquals($secondSearchResult->getDocuments(), $result->getDocuments());
+    }
+
+    function testFetchNextWithScroll()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $firstDocumentId = uniqid();
+        $firstDocumentContent = [
+            'name' => 'John',
+            'age' => 42
+        ];
+
+        $secondDocumentId = uniqid();
+        $secondDocumentContent = [
+            'name' => 'Michael',
+            'age' => 36
+        ];
+
+        $firstDocument = new Document($dataCollection, $firstDocumentId, $firstDocumentContent);
+        $secondDocument = new Document($dataCollection, $secondDocumentId, $secondDocumentContent);
+
+        $documents = [$firstDocument];
+
+        $scrollId = uniqid();
+
+        $httpRequest = [
+            'route' => '/_scroll/' . $scrollId,
+            'method' => 'GET',
+            'request' => [
+                'volatile' => [],
+                'controller' => 'document',
+                'action' => 'scroll',
+                'requestId' => $requestId
+            ],
+            'query_parameters' => []
+        ];
+
+        $searchResponse = [
+            'hits' => [
+                0 => [
+                    '_id' => $secondDocumentId,
+                    '_source' => $secondDocumentContent,
+                    '_meta' => []
+                ]
+            ],
+            'total' => 42
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $searchResponse
+        ];
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        $options = ['from' => 0, 'size' => 1, 'scrollId' => $scrollId, 'requestId' => $requestId];
+        $filters = ['sort' => [['age' => 'desc']]];
+
+        $initialSearchResult = new SearchResult($dataCollection, 42, $documents, [], $options, $filters);
+
+        $result = $initialSearchResult->fetchNext();
+
+        $secondSearchResult = new SearchResult($dataCollection, 42, [$secondDocument], [], $options, $filters);
+
+        $this->assertEquals($secondSearchResult->getDocuments(), $result->getDocuments());
+    }
+
+    function testFetchNextWithSearchFromSize()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $firstDocumentId = uniqid();
+        $firstDocumentContent = [
+            'name' => 'John',
+            'age' => 42
+        ];
+
+        $secondDocumentId = uniqid();
+        $secondDocumentContent = [
+            'name' => 'Michael',
+            'age' => 36
+        ];
+
+        $firstDocument = new Document($dataCollection, $firstDocumentId, $firstDocumentContent);
+        $secondDocument = new Document($dataCollection, $secondDocumentId, $secondDocumentContent);
+
+        $documents = [$firstDocument];
+
+        $httpRequest = [
+            'route' => '/' . $index . '/' . $collection . '/_search',
+            'method' => 'POST',
+            'request' => [
+                'volatile' => [],
+                'controller' => 'document',
+                'action' => 'search',
+                'requestId' => $requestId,
+                'collection' => $collection,
+                'index' => $index,
+                'body' => ['sort' => [['age' => 'desc']]]
+            ],
+            'query_parameters' => ['from' => 1, 'size' => 1]
+        ];
+
+        $searchResponse = [
+            'hits' => [
+                0 => [
+                    '_id' => $secondDocumentId,
+                    '_source' => $secondDocumentContent,
+                    '_meta' => []
+                ]
+            ],
+            'total' => 42
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $searchResponse
+        ];
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        $options = ['from' => 0, 'size' => 1, 'requestId' => $requestId];
+        $filters = ['sort' => [['age' => 'desc']]];
+
+        $initialSearchResult = new SearchResult($dataCollection, 42, $documents, [], $options, $filters);
+
+        $result = $initialSearchResult->fetchNext();
+
+        $secondSearchResult = new SearchResult($dataCollection, 42, [$secondDocument], [], $options, $filters);
+
+        $this->assertEquals($secondSearchResult->getDocuments(), $result->getDocuments());
+    }
+}

--- a/tests/SearchResultTest.php
+++ b/tests/SearchResultTest.php
@@ -251,7 +251,7 @@ class SearchResultTestTest extends \PHPUnit_Framework_TestCase
                 'requestId' => $requestId,
                 'collection' => $collection,
                 'index' => $index,
-                'body' => ['sort' => [['age' => 'desc']]]
+                'body' => (object)[]
             ],
             'query_parameters' => ['from' => 1, 'size' => 1]
         ];
@@ -278,7 +278,7 @@ class SearchResultTestTest extends \PHPUnit_Framework_TestCase
             ->willReturn($httpResponse);
 
         $options = ['from' => 0, 'size' => 1, 'requestId' => $requestId];
-        $filters = ['sort' => [['age' => 'desc']]];
+        $filters = [];
 
         $initialSearchResult = new SearchResult($dataCollection, 42, $documents, [], $options, $filters);
 


### PR DESCRIPTION
## Introduces
- Way to use ES's search_after if conditions are met when calling SearchResult:fetchNext (better than using scrolls, bypasses the default search limit count)
- New unit tests to cover SearchResult functionalities

## Related issue
https://github.com/kuzzleio/kuzzle/issues/856

## Boyscoot
- Updates README.md (typos / various)
- PHPDoc fixes, invalid variable names, code cleanup