### PR TITLE
Release 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/kuzzleio/sdk-php.svg?branch=master)](https://travis-ci.org/kuzzleio/sdk-php) [![codecov.io](http://codecov.io/github/kuzzleio/sdk-php/coverage.svg?branch=master)](http://codecov.io/github/kuzzleio/sdk-php?branch=master)
+
 Official Kuzzle PHP SDK
 ======
 
@@ -10,6 +12,7 @@ You can access the Kuzzle repository on [Github](https://github.com/kuzzleio/kuz
 * [SDK Documentation](#sdk-documentation)
 * [Report an issue](#report-an-issue)
 * [Installation](#installation)
+* [Basic usage](#basic-usage)
 * [Running tests](#tests)
 * [License](#license)
 
@@ -29,6 +32,30 @@ This SDK can be used in any project using composer:
 
 ```
 composer require kuzzleio/kuzzle-sdk
+```
+
+## Basic usage
+
+```php
+<?php
+
+use \Kuzzle\Kuzzle;
+use \Kuzzle\Document;
+
+$kuzzle = new Kuzzle('localhost');
+$collection = $kuzzle->collection('bar', 'foo');
+
+$firstDocument = new Document($collection, 'john', ['name' => 'John', 'age' => 42]);
+$secondDocument = new Document($collection, 'michael', ['name' => 'Michael', 'age' => 36]);
+
+$firstDocument->save(['refresh' => 'wait_for']);
+$secondDocument->save(['refresh' => 'wait_for']);
+
+$result = $collection->search(['sort' => [['age' => 'asc']]]);
+foreach ($result->getDocuments() as $document) {
+    $content = $document->getContent();
+    echo "Name: {$content['name']}, age: {$content['age']}\n";
+}
 ```
 
 ## <a name="tests"></a> Running Tests

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,16 @@
 {
   "name": "kuzzleio/kuzzle-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Official PHP SDK for Kuzzle",
   "homepage": "http://kuzzle.io",
   "license": "Apache-2.0",
-  "authors": [{
-    "name": "The Kuzzle Team",
-    "email": "support@kuzzle.io",
-    "homepage": "http://kuzzle.io"
-  }],
+  "authors": [
+    {
+      "name": "The Kuzzle Team",
+      "email": "support@kuzzle.io",
+      "homepage": "http://kuzzle.io"
+    }
+  ],
   "support": {
     "issues": "https://github.com/kuzzleio/sdk-php/issues"
   },
@@ -17,12 +19,12 @@
       "Kuzzle\\": "src/"
     }
   },
-  "require" : {
+  "require": {
     "php": ">=5.4",
     "ramsey/uuid": "^3.4",
     "ext-curl": "*"
   },
-  "require-dev" : {
+  "require-dev": {
     "phpunit/phpunit": "4.8.*",
     "phpdocumentor/phpdocumentor": "2.9.0",
     "squizlabs/php_codesniffer": "2.*"

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -785,8 +785,8 @@ class Collection
     }
 
     /**
-     * @param $controller
-     * @param $action
+     * @param string $controller
+     * @param string $action
      * @return array
      */
     public function buildQueryArgs($controller, $action)

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -571,17 +571,10 @@ class Kuzzle
                 $httpParams['query_parameters'] = array_merge($httpParams['query_parameters'], $options['query_parameters']);
             }
 
-            if (array_key_exists('refresh', $options)) {
-                $httpParams['query_parameters']['refresh'] = $options['refresh'];
-            }
-            if (array_key_exists('from', $options)) {
-                $httpParams['query_parameters']['from'] = $options['from'];
-            }
-            if (array_key_exists('size', $options)) {
-                $httpParams['query_parameters']['size'] = $options['size'];
-            }
-            if (array_key_exists('scroll', $options)) {
-                $httpParams['query_parameters']['scroll'] = $options['scroll'];
+            foreach (['refresh', 'from', 'size', 'scroll'] as $optionParam) {
+                if (array_key_exists($optionParam, $options)) {
+                    $httpParams['query_parameters'][$optionParam] = $options[$optionParam];
+                }
             }
         }
 
@@ -613,20 +606,10 @@ class Kuzzle
             $request['headers']['authorization'] = 'Bearer ' . $this->jwtToken;
         }
 
-        if (array_key_exists('collection', $queryArgs)) {
-            $request['collection'] = $queryArgs['collection'];
-        }
-
-        if (array_key_exists('route', $queryArgs)) {
-            $request['route'] = $queryArgs['route'];
-        }
-
-        if (array_key_exists('method', $queryArgs)) {
-            $request['method'] = $queryArgs['method'];
-        }
-
-        if (array_key_exists('index', $queryArgs)) {
-            $request['index'] = $queryArgs['index'];
+        foreach (['collection', 'route', 'method', 'index'] as $queryArg) {
+            if (array_key_exists($queryArg, $queryArgs)) {
+                $request[$queryArg] = $queryArgs[$queryArg];
+            }
         }
 
         if (!array_key_exists('requestId', $request)) {

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -854,7 +854,7 @@ class Kuzzle
             $options
         );
 
-        return new User($this->security(), $response['result']['_id'], $response['result']['_source']);
+        return new User($this->security(), $response['result']['_id'], $response['result']['_source'], $response['result']['_meta']);
     }
 
     /**

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -424,16 +424,16 @@ class Kuzzle
             throw new InvalidArgumentException('Unable to login: no strategy specified');
         }
 
-        if (!empty($expiresIn)) {
-            $body['expiresIn'] = $expiresIn;
-        }
-
         if (!array_key_exists('httpParams', $options)) {
             $options['httpParams'] = [];
         }
 
         if (!array_key_exists(':strategy', $options['httpParams'])) {
             $options['httpParams'][':strategy'] = $strategy;
+        }
+
+        if (!empty($expiresIn)) {
+            $options['query_parameters']['expiresIn'] = $expiresIn;
         }
 
         $response = $this->query(

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -78,6 +78,11 @@ class Kuzzle
      */
     protected $requestHandler;
 
+    /**
+     * @var string
+     */
+    protected $sdkVersion;
+
 
     /**
      * Kuzzle constructor.
@@ -108,9 +113,10 @@ class Kuzzle
             $this->port = $options['port'];
         }
 
-
         $this->url = 'http://' . $host . ':' . $this->port;
         $this->loadRoutesDescription($this->routesDescriptionFile);
+
+        $this->sdkVersion = json_decode(file_get_contents('./composer.json'))->version;
 
         return $this;
     }
@@ -122,6 +128,7 @@ class Kuzzle
      * @param string $event One of the event described in the Event Handling section of the kuzzle documentation
      * @param callable $listener The function to call each time one of the registered event is fired
      *
+     * @return Kuzzle
      * @throws InvalidArgumentException
      */
     public function addListener($event, $listener)
@@ -144,6 +151,7 @@ class Kuzzle
      *
      * @param string $event One of the event described in the Event Handling section of the kuzzle documentation
      *
+     * @return Kuzzle
      */
     public function emitEvent($event)
     {
@@ -154,6 +162,7 @@ class Kuzzle
                 call_user_func_array($callback, $arg_list);
             }
         }
+
         return $this;
     }
 
@@ -841,6 +850,14 @@ class Kuzzle
     }
 
     /**
+     * @return string
+     */
+    public function getSdkVersion()
+    {
+        return $this->sdkVersion;
+    }
+
+    /**
      * Retrieves current user object.
      *
      * @param array $options (optional) arguments
@@ -999,6 +1016,7 @@ class Kuzzle
                 $headers[] = ucfirst($header) . ': ' . $value;
             }
         }
+        $headers[] = 'X-Kuzzle-Volatile: ' . json_encode(array_merge($this->getVolatile(), ['sdkVersion' => $this->getSdkVersion()]));
 
         if (array_key_exists('body', $httpRequest['request'])) {
             $body = json_encode($httpRequest['request']['body']);

--- a/src/Security/Document.php
+++ b/src/Security/Document.php
@@ -30,18 +30,25 @@ abstract class Document
     protected $content;
 
     /**
+     * @var array The metadata of the document
+     */
+    protected $meta;
+
+    /**
      * Document constructor.
      *
      * @param Security $kuzzleSecurity An instantiated Kuzzle\Security object
      * @param string $id Unique document identifier
      * @param array $content Document content
-     * @return Document
+     * @param array $meta Document metadata
      */
-    public function __construct(Security $kuzzleSecurity, $id = '', array $content = [])
+    public function
+    __construct(Security $kuzzleSecurity, $id = '', array $content = [], array $meta = [])
     {
         $this->security = $kuzzleSecurity;
         $this->id = $id;
         $this->content = $content;
+        $this->meta = $meta;
 
         return $this;
     }
@@ -67,6 +74,16 @@ abstract class Document
     public function getContent()
     {
         return $this->content;
+    }
+
+    /**
+     * Return the metadata of the SecurityDocument
+     *
+     * @return array
+     */
+    public function getMeta()
+    {
+        return $this->meta;
     }
 
     /**

--- a/src/Security/Document.php
+++ b/src/Security/Document.php
@@ -42,8 +42,7 @@ abstract class Document
      * @param array $content Document content
      * @param array $meta Document metadata
      */
-    public function
-    __construct(Security $kuzzleSecurity, $id = '', array $content = [], array $meta = [])
+    public function __construct(Security $kuzzleSecurity, $id = '', array $content = [], array $meta = [])
     {
         $this->security = $kuzzleSecurity;
         $this->id = $id;

--- a/src/Security/Profile.php
+++ b/src/Security/Profile.php
@@ -26,11 +26,11 @@ class Profile extends Document
      * @param Security $kuzzleSecurity An instantiated Kuzzle\Security object
      * @param string $id Unique profile identifier
      * @param array $content Profile content
-     * @return Profile
+     * @param array $meta Profile metadata
      */
-    public function __construct(Security $kuzzleSecurity, $id = '', array $content = [])
+    public function __construct(Security $kuzzleSecurity, $id = '', array $content = [], array $meta = [])
     {
-        parent::__construct($kuzzleSecurity, $id, $content);
+        parent::__construct($kuzzleSecurity, $id, $content, $meta);
 
         $this->syncPolicies();
 

--- a/src/Security/Role.php
+++ b/src/Security/Role.php
@@ -20,11 +20,11 @@ class Role extends Document
      * @param Security $kuzzleSecurity An instantiated Kuzzle\Security object
      * @param string $id Unique role identifier
      * @param array $content Role content
-     * @return Role
+     * @param array $meta Role metadata
      */
-    public function __construct(Security $kuzzleSecurity, $id = '', array $content = [])
+    public function __construct(Security $kuzzleSecurity, $id = '', array $content = [], array $meta = [])
     {
-        parent::__construct($kuzzleSecurity, $id, $content);
+        parent::__construct($kuzzleSecurity, $id, $content, $meta);
 
         return $this;
     }

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -52,7 +52,7 @@ class Security
     /**
      * Create a new profile in Kuzzle.
      *
-     * @param integer $id Unique profile identifier
+     * @param string $id Unique profile identifier
      * @param array $policies List of policies to apply to this profile
      * @param array $options Optional arguments
      * @return Profile
@@ -75,7 +75,7 @@ class Security
             $options
         );
 
-        return new Profile($this, $response['result']['_id'], $response['result']['_source']);
+        return new Profile($this, $response['result']['_id'], $response['result']['_source'], $response['result']['_meta']);
     }
 
     /**
@@ -104,7 +104,7 @@ class Security
             $options
         );
 
-        return new Role($this, $response['result']['_id'], $response['result']['_source']);
+        return new Role($this, $response['result']['_id'], $response['result']['_source'], $response['result']['_meta']);
     }
 
     /**
@@ -129,7 +129,7 @@ class Security
             $options
         );
 
-        return new User($this, $response['result']['_id'], $response['result']['_source']);
+        return new User($this, $response['result']['_id'], $response['result']['_source'], $response['result']['_meta']);
     }
 
     /**
@@ -154,7 +154,7 @@ class Security
             $options
         );
 
-        return new User($this, $response['result']['_id'], $response['result']['_source']);
+        return new User($this, $response['result']['_id'], $response['result']['_source'], $response['result']['_meta']);
     }
 
     /**
@@ -179,7 +179,7 @@ class Security
             $options
         );
 
-        return new User($this, $response['result']['_id'], $response['result']['_source']);
+        return new User($this, $response['result']['_id'], $response['result']['_source'], $response['result']['_meta']);
     }
 
     /**
@@ -233,7 +233,7 @@ class Security
         );
 
         $response['result']['hits'] = array_map(function ($document) {
-            return new Profile($this, $document['_id'], $document['_source']);
+            return new Profile($this, $document['_id'], $document['_source'], $document['_meta']);
         }, $response['result']['hits']);
 
         return new ProfilesSearchResult(
@@ -316,7 +316,7 @@ class Security
         );
 
         $response['result']['hits'] = array_map(function ($document) {
-            return new User($this, $document['_id'], $document['_source']);
+            return new User($this, $document['_id'], $document['_source'], $document['_meta']);
         }, $response['result']['hits']);
 
         return new UsersSearchResult(
@@ -345,7 +345,7 @@ class Security
             $options
         );
 
-        return new Profile($this, $response['result']['_id'], $response['result']['_source']);
+        return new Profile($this, $response['result']['_id'], $response['result']['_source'], $response['result']['_meta']);
     }
 
     /**
@@ -367,7 +367,7 @@ class Security
             $options
         );
 
-        return new Role($this, $response['result']['_id'], $response['result']['_source']);
+        return new Role($this, $response['result']['_id'], $response['result']['_source'], $response['result']['_meta']);
     }
 
     /**
@@ -389,7 +389,7 @@ class Security
             $options
         );
 
-        return new User($this, $response['result']['_id'], $response['result']['_source']);
+        return new User($this, $response['result']['_id'], $response['result']['_source'], $response['result']['_meta']);
     }
 
     /**
@@ -469,11 +469,12 @@ class Security
      *
      * @param string $id Unique profile identifier
      * @param array $content Profile content
+     * @param array $meta Profile metadata
      * @return Profile
      */
-    public function profile($id, array $content)
+    public function profile($id, array $content, array $meta = [])
     {
-        return new Profile($this, $id, $content);
+        return new Profile($this, $id, $content, $meta);
     }
 
     /**
@@ -481,11 +482,12 @@ class Security
      *
      * @param string $id Unique role identifier
      * @param array $content Role content
+     * @param array $meta Role metadata
      * @return Role
      */
-    public function role($id, array $content)
+    public function role($id, array $content, array $meta = [])
     {
-        return new Role($this, $id, $content);
+        return new Role($this, $id, $content, $meta);
     }
 
     /**
@@ -493,11 +495,12 @@ class Security
      *
      * @param string $id Unique user identifier
      * @param array $content User content
+     * @param array $meta User metadata
      * @return User
      */
-    public function user($id, array $content)
+    public function user($id, array $content, array $meta = [])
     {
-        return new User($this, $id, $content);
+        return new User($this, $id, $content, $meta);
     }
 
     /**
@@ -522,7 +525,7 @@ class Security
         );
 
         $response['result']['hits'] = array_map(function ($profile) {
-            return new Profile($this, $profile['_id'], $profile['_source']);
+            return new Profile($this, $profile['_id'], $profile['_source'], $profile['_meta']);
         }, $response['result']['hits']);
 
         if (isset($response['result']['scrollId'])) {
@@ -552,7 +555,7 @@ class Security
         );
 
         $response['result']['hits'] = array_map(function ($role) {
-            return new Role($this, $role['_id'], $role['_source']);
+            return new Role($this, $role['_id'], $role['_source'], $role['_meta']);
         }, $response['result']['hits']);
 
         return new RolesSearchResult($response['result']['total'], $response['result']['hits']);
@@ -580,7 +583,7 @@ class Security
         );
 
         $response['result']['hits'] = array_map(function ($user) {
-            return new User($this, $user['_id'], $user['_source']);
+            return new User($this, $user['_id'], $user['_source'], $user['_meta']);
         }, $response['result']['hits']);
 
         if (isset($response['result']['scrollId'])) {
@@ -611,7 +614,7 @@ class Security
             $options
         );
 
-        return new Profile($this, $id, $response['result']['_source']);
+        return new Profile($this, $id, $response['result']['_source'], $response['result']['_meta']);
     }
 
     /**
@@ -635,7 +638,7 @@ class Security
             $options
         );
 
-        return new Role($this, $id, $response['result']['_source']);
+        return new Role($this, $id, $response['result']['_source'], $response['result']['_meta']);
     }
 
     /**
@@ -659,7 +662,7 @@ class Security
             $options
         );
 
-        return new User($this, $id, $response['result']['_source']);
+        return new User($this, $id, $response['result']['_source'], $response['result']['_meta']);
     }
 
     /**

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -26,11 +26,12 @@ class User extends Document
      * @param Security $kuzzleSecurity An instantiated Kuzzle\Security object
      * @param string $id Unique user identifier
      * @param array $content User content
+     * @param array $meta User metadata
      * @return User
      */
-    public function __construct(Security $kuzzleSecurity, $id = '', array $content = [])
+    public function __construct(Security $kuzzleSecurity, $id = '', array $content = [], array $meta = [])
     {
-        parent::__construct($kuzzleSecurity, $id, $content);
+        parent::__construct($kuzzleSecurity, $id, $content, $meta);
 
         $this->syncProfile();
 

--- a/src/Util/SearchResult.php
+++ b/src/Util/SearchResult.php
@@ -55,18 +55,18 @@ class SearchResult
      * @param Document[] $documents
      * @param array $aggregations
      * @param array $options
-     * @param array $fiters
+     * @param array $filters
      * @param SearchResult $previous
      * @internal param array $searchArgs
      */
-    public function __construct(Collection $collection, $total, array $documents, array $aggregations = [], array $options = [], array $fiters = [], SearchResult $previous = null)
+    public function __construct(Collection $collection, $total, array $documents, array $aggregations = [], array $options = [], array $filters = [], SearchResult $previous = null)
     {
         $this->collection = $collection;
         $this->total = $total;
         $this->documents = $documents;
         $this->aggregations = $aggregations;
         $this->options = $options;
-        $this->filters = $fiters;
+        $this->filters = $filters;
         $this->fetchedDocuments = count($documents) + ($previous instanceof SearchResult ? $previous->fetchedDocuments : 0);
 
         return $this;
@@ -157,6 +157,21 @@ class SearchResult
                 $options,
                 $this->filters
             );
+        } else if (array_key_exists('size', $this->options) && array_key_exists('sort', $this->filters)) {
+            // retrieve next results using ES's search_after
+            if ($this->fetchedDocuments >= $this->getTotal()) {
+                return null;
+            }
+
+            $options = $this->options;
+            unset($options['from']);
+
+            $filters = $this->filters;
+            $filters['search_after'] = array_map(function ($sortRule) {
+                return end($this->documents)->getContent()[key($sortRule)];
+            }, $this->filters['sort']);
+
+            $searchResult = $this->collection->search($filters, $options);
         } else if (array_key_exists('from', $this->options) && array_key_exists('size', $this->options)) {
             // retrieve next results with  from/size if original search use it
             $filters = $this->filters;

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -217,14 +217,14 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
                 'index' => $index,
                 '_id' => $documentId,
                 'body' => array_merge($documentContent, ['baz' => 'baz']),
-                'meta' => array_merge($documentMeta, ['author' => 'bar']),
+                'meta' => ['author' => 'bar'],
             ],
             'query_parameters' => []
         ];
         $saveResponse = [
             '_id' => $documentId,
-            '_source' => $documentContent,
-            '_meta' => $documentMeta,
+            '_source' => array_merge($documentContent, ['baz' => 'baz']),
+            '_meta' => ['author' => 'bar'],
             '_version' => 1
         ];
         $httpResponse = [

--- a/tests/KuzzleTest.php
+++ b/tests/KuzzleTest.php
@@ -402,10 +402,7 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetServerInfo()
     {
-        /**
-         * @todo: missing server info http route in kuzzle
-         */
-        /*$url = self::FAKE_KUZZLE_HOST;
+        $url = self::FAKE_KUZZLE_HOST;
 
         $kuzzle = $this
             ->getMockBuilder('\Kuzzle\Kuzzle')
@@ -426,7 +423,8 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
                 'volatile' => [],
                 'requestId' => $options['requestId']
             ],
-            'method' => 'GET'
+            'method' => 'GET',
+            'query_parameters' => []
         ];
 
         // mock response
@@ -444,7 +442,7 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
 
         $response = $kuzzle->getServerInfo($options);
 
-        $this->assertEquals($getServerInfoResponse['serverInfo'], $response);*/
+        $this->assertEquals($getServerInfoResponse['serverInfo'], $response);
     }
 
     public function testGetLastStatistics()
@@ -1321,10 +1319,13 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
 
         $kuzzle = new \Kuzzle\Kuzzle(self::FAKE_KUZZLE_HOST, ['requestHandler' => $curlRequestHandler]);
 
+        $volatile = ['sdkVersion' => $kuzzle->getSdkVersion()];
+
         $httpRequest = [
             'request' => [
                 'headers' => ['authorization' => 'Bearer ' . uniqid()],
-                'body' => ['foo' => 'bar']
+                'body' => ['foo' => 'bar'],
+                'volatile' => $volatile
             ],
             'route' => '/foo/bar',
             'method' => 'POST',
@@ -1339,6 +1340,7 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
             'headers' => [
                 'Content-type: application/json',
                 'Authorization: ' . $httpRequest['request']['headers']['authorization'],
+                'X-Kuzzle-Volatile: ' . json_encode($volatile),
                 'Content-length: ' . strlen($body)
             ],
             'body' => $body,
@@ -1375,10 +1377,13 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
 
         $kuzzle = new \Kuzzle\Kuzzle(self::FAKE_KUZZLE_HOST, ['requestHandler' => $curlRequestHandler]);
 
+        $volatile = ['sdkVersion' => $kuzzle->getSdkVersion()];
+
         $httpRequest = [
             'request' => [
                 'headers' => ['authorization' => 'Bearer ' . uniqid()],
-                'body' => ['foo' => 'bar']
+                'body' => ['foo' => 'bar'],
+                'volatile' => $volatile
             ],
             'route' => '/foo/bar',
             'method' => 'POST',
@@ -1393,6 +1398,7 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
             'headers' => [
                 'Content-type: application/json',
                 'Authorization: ' . $httpRequest['request']['headers']['authorization'],
+                'X-Kuzzle-Volatile: ' . json_encode($volatile),
                 'Content-length: ' . strlen($body)
             ],
             'body' => $body,
@@ -1443,10 +1449,13 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
         $emitRestRequest = $reflection->getMethod('emitRestRequest');
         $emitRestRequest->setAccessible(true);
 
+        $volatile = ['sdkVersion' => $kuzzle->getSdkVersion()];
+
         $httpRequest = [
             'request' => [
                 'headers' => ['authorization' => 'Bearer ' . uniqid()],
-                'body' => ['foo' => 'bar']
+                'body' => ['foo' => 'bar'],
+                'volatile' => $volatile
             ],
             'route' => '/foo/bar',
             'method' => 'POST',
@@ -1461,6 +1470,7 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
             'headers' => [
                 'Content-type: application/json',
                 'Authorization: ' . $httpRequest['request']['headers']['authorization'],
+                'X-Kuzzle-Volatile: ' . json_encode($volatile),
                 'Content-length: ' . strlen($body)
             ],
             'body' => $body,

--- a/tests/KuzzleTest.php
+++ b/tests/KuzzleTest.php
@@ -812,12 +812,13 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
                 'body' => [
                     'username' => $credentials['username'],
                     'password' => $credentials['password'],
-                    'expiresIn' => $expiresIn,
                 ],
                 'requestId' => $options['requestId']
             ],
             'method' => 'POST',
-            'query_parameters' => []
+            'query_parameters' => [
+              'expiresIn' => $expiresIn
+            ]
         ];
 
         // mock response
@@ -1327,7 +1328,7 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
             ],
             'route' => '/foo/bar',
             'method' => 'POST',
-            'query_parameters' => []
+            'query_parameters' => ['foo' => 'bar']
         ];
 
         $body = json_encode($httpRequest['request']['body'], JSON_FORCE_OBJECT);
@@ -1341,7 +1342,7 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
                 'Content-length: ' . strlen($body)
             ],
             'body' => $body,
-            'query_parameters' => []
+            'query_parameters' => ['foo' => 'bar']
         ];
 
         $reflection = new \ReflectionClass(get_class($kuzzle));
@@ -1505,7 +1506,8 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
             'body' => ['foo' => 'bar']
         ];
         $httpParams = [
-            ':custom' => 'custom-param'
+            ':custom' => 'custom-param',
+            'query_parameters' => ['foo' => 'bar']
         ];
 
         $expectedHttpRequest = [
@@ -1518,7 +1520,8 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
                 'index' => $request['index'],
                 '_id' => $request['_id'],
                 'body' => $request['body']
-            ]
+            ],
+            'query_parameters' => ['foo' => 'bar']
         ];
 
         $kuzzle = new \Kuzzle\Kuzzle(self::FAKE_KUZZLE_HOST);
@@ -1527,14 +1530,9 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
         $convertRestRequest = $reflection->getMethod('convertRestRequest');
         $convertRestRequest->setAccessible(true);
 
-        try {
-            $httpRequest = $convertRestRequest->invokeArgs($kuzzle, [$request, $httpParams]);
+        $httpRequest = $convertRestRequest->invokeArgs($kuzzle, [$request, $httpParams]);
 
-            $this->assertEquals($expectedHttpRequest, $httpRequest);
-        }
-        catch (Exception $e) {
-            $this->fail("KuzzleTest::testConvertRestRequest => Should not raise an exception");
-        }
+        $this->assertEquals($expectedHttpRequest, $httpRequest);
     }
 
     public function testConvertRestRequestWithBadController()

--- a/tests/KuzzleTest.php
+++ b/tests/KuzzleTest.php
@@ -1279,7 +1279,8 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
             '_source' => [
                 'profileIds' => ['admin'],
                 'foo' => 'bar'
-            ]
+            ],
+            '_meta' => []
         ];
         $httpResponse = [
             'error' => null,

--- a/tests/SearchResultTest.php
+++ b/tests/SearchResultTest.php
@@ -1,0 +1,291 @@
+<?php
+
+use Kuzzle\Document;
+use Kuzzle\Collection;
+use Kuzzle\Util\SearchResult;
+
+class SearchResultTestTest extends \PHPUnit_Framework_TestCase
+{
+    function testSearchResultMethods()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $index = 'index';
+        $collection = 'collection';
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $firstDocumentId = uniqid();
+        $firstDocumentContent = [
+            'name' => 'John',
+            'age' => 42
+        ];
+
+        $secondDocumentId = uniqid();
+        $secondDocumentContent = [
+            'name' => 'Michael',
+            'age' => 36
+        ];
+
+        $documents = [
+            new Document($dataCollection, $firstDocumentId, $firstDocumentContent),
+            new Document($dataCollection, $secondDocumentId, $secondDocumentContent)
+        ];
+
+        $options = ['from' => 0, 'size' => 1];
+        $filters = ['sort' => [['age' => 'desc']]];
+
+        $searchResult = new SearchResult($dataCollection, 42, $documents, [], $options, $filters);
+
+        $this->assertEquals($searchResult->getTotal(), 42);
+        $this->assertEquals($searchResult->getDocuments(), $documents);
+        $this->assertEquals($searchResult->getOptions(), $options);
+        $this->assertEquals($searchResult->getFilters(), $filters);
+        $this->assertEquals($searchResult->getCollection(), $dataCollection);
+        $this->assertEquals($searchResult->getFetchedDocuments(), 2);
+    }
+
+    function testFetchNextWithSearchAfter()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $firstDocumentId = uniqid();
+        $firstDocumentContent = [
+            'name' => 'John',
+            'age' => 42
+        ];
+
+        $secondDocumentId = uniqid();
+        $secondDocumentContent = [
+            'name' => 'Michael',
+            'age' => 36
+        ];
+
+        $firstDocument = new Document($dataCollection, $firstDocumentId, $firstDocumentContent);
+        $secondDocument = new Document($dataCollection, $secondDocumentId, $secondDocumentContent);
+
+        $documents = [$firstDocument];
+
+        $httpRequest = [
+            'route' => '/' . $index . '/' . $collection . '/_search',
+            'method' => 'POST',
+            'request' => [
+                'volatile' => [],
+                'controller' => 'document',
+                'action' => 'search',
+                'requestId' => $requestId,
+                'collection' => $collection,
+                'index' => $index,
+                'body' => ['sort' => [['age' => 'desc']], 'search_after' => [42]]
+            ],
+            'query_parameters' => ['size' => 1]
+        ];
+
+        $searchResponse = [
+            'hits' => [
+                0 => [
+                    '_id' => $secondDocumentId,
+                    '_source' => $secondDocumentContent,
+                    '_meta' => []
+                ]
+            ],
+            'total' => 42
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $searchResponse
+        ];
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        $options = ['size' => 1, 'requestId' => $requestId];
+        $filters = ['sort' => [['age' => 'desc']]];
+
+        $initialSearchResult = new SearchResult($dataCollection, 42, $documents, [], $options, $filters);
+
+        $result = $initialSearchResult->fetchNext();
+
+        $secondSearchResult = new SearchResult($dataCollection, 42, [$secondDocument], [], $options, $filters);
+
+        $this->assertEquals($secondSearchResult->getDocuments(), $result->getDocuments());
+    }
+
+    function testFetchNextWithScroll()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $firstDocumentId = uniqid();
+        $firstDocumentContent = [
+            'name' => 'John',
+            'age' => 42
+        ];
+
+        $secondDocumentId = uniqid();
+        $secondDocumentContent = [
+            'name' => 'Michael',
+            'age' => 36
+        ];
+
+        $firstDocument = new Document($dataCollection, $firstDocumentId, $firstDocumentContent);
+        $secondDocument = new Document($dataCollection, $secondDocumentId, $secondDocumentContent);
+
+        $documents = [$firstDocument];
+
+        $scrollId = uniqid();
+
+        $httpRequest = [
+            'route' => '/_scroll/' . $scrollId,
+            'method' => 'GET',
+            'request' => [
+                'volatile' => [],
+                'controller' => 'document',
+                'action' => 'scroll',
+                'requestId' => $requestId
+            ],
+            'query_parameters' => []
+        ];
+
+        $searchResponse = [
+            'hits' => [
+                0 => [
+                    '_id' => $secondDocumentId,
+                    '_source' => $secondDocumentContent,
+                    '_meta' => []
+                ]
+            ],
+            'total' => 42
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $searchResponse
+        ];
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        $options = ['from' => 0, 'size' => 1, 'scrollId' => $scrollId, 'requestId' => $requestId];
+        $filters = ['sort' => [['age' => 'desc']]];
+
+        $initialSearchResult = new SearchResult($dataCollection, 42, $documents, [], $options, $filters);
+
+        $result = $initialSearchResult->fetchNext();
+
+        $secondSearchResult = new SearchResult($dataCollection, 42, [$secondDocument], [], $options, $filters);
+
+        $this->assertEquals($secondSearchResult->getDocuments(), $result->getDocuments());
+    }
+
+    function testFetchNextWithSearchFromSize()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+        $requestId = uniqid();
+        $index = 'index';
+        $collection = 'collection';
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $dataCollection = new Collection($kuzzle, $collection, $index);
+
+        $firstDocumentId = uniqid();
+        $firstDocumentContent = [
+            'name' => 'John',
+            'age' => 42
+        ];
+
+        $secondDocumentId = uniqid();
+        $secondDocumentContent = [
+            'name' => 'Michael',
+            'age' => 36
+        ];
+
+        $firstDocument = new Document($dataCollection, $firstDocumentId, $firstDocumentContent);
+        $secondDocument = new Document($dataCollection, $secondDocumentId, $secondDocumentContent);
+
+        $documents = [$firstDocument];
+
+        $httpRequest = [
+            'route' => '/' . $index . '/' . $collection . '/_search',
+            'method' => 'POST',
+            'request' => [
+                'volatile' => [],
+                'controller' => 'document',
+                'action' => 'search',
+                'requestId' => $requestId,
+                'collection' => $collection,
+                'index' => $index,
+                'body' => (object)[]
+            ],
+            'query_parameters' => ['from' => 1, 'size' => 1]
+        ];
+
+        $searchResponse = [
+            'hits' => [
+                0 => [
+                    '_id' => $secondDocumentId,
+                    '_source' => $secondDocumentContent,
+                    '_meta' => []
+                ]
+            ],
+            'total' => 42
+        ];
+        $httpResponse = [
+            'error' => null,
+            'result' => $searchResponse
+        ];
+
+        $kuzzle
+            ->expects($this->once())
+            ->method('emitRestRequest')
+            ->with($httpRequest)
+            ->willReturn($httpResponse);
+
+        $options = ['from' => 0, 'size' => 1, 'requestId' => $requestId];
+        $filters = [];
+
+        $initialSearchResult = new SearchResult($dataCollection, 42, $documents, [], $options, $filters);
+
+        $result = $initialSearchResult->fetchNext();
+
+        $secondSearchResult = new SearchResult($dataCollection, 42, [$secondDocument], [], $options, $filters);
+
+        $this->assertEquals($secondSearchResult->getDocuments(), $result->getDocuments());
+    }
+}

--- a/tests/Security/ProfileTest.php
+++ b/tests/Security/ProfileTest.php
@@ -273,4 +273,25 @@ class ProfileTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($roleId, 'roleId', $policies[0]);
         $this->assertAttributeEquals(array_merge($policyDescription['restrictedTo'], [['index' => 'foo-bar']]), 'restrictedTo', $policies[0]);
     }
+
+    function testGetMeta()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $metas = [
+            'createdAt' => '0123456789',
+            'author' => '-1'
+        ];
+
+        $security = new Security($kuzzle);
+        $profile = new Profile($security, 'foobar', [], $metas);
+
+        $this->assertEquals($profile->getMeta(), $metas);
+    }
 }

--- a/tests/Security/RoleTest.php
+++ b/tests/Security/RoleTest.php
@@ -191,4 +191,25 @@ class RoleTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($roleId, $result);
     }
+
+    function testGetMeta()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $metas = [
+            'createdAt' => '0123456789',
+            'author' => '-1'
+        ];
+
+        $security = new Security($kuzzle);
+        $role = new Role($security, 'foobar', [], $metas);
+
+        $this->assertEquals($role->getMeta(), $metas);
+    }
 }

--- a/tests/Security/SecurityTest.php
+++ b/tests/Security/SecurityTest.php
@@ -34,6 +34,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $saveResponse = [
             '_id' => $profileId,
             '_source' => [ 'policies' => $policies ],
+            '_meta' => [],
             '_version' => 1
         ];
         $httpResponse = [
@@ -94,6 +95,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $saveResponse = [
             '_id' => $profileId,
             '_source' => [ 'policies' => $policies ],
+            '_meta' => [],
             '_version' => 1
         ];
         $httpResponse = [
@@ -161,6 +163,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $saveResponse = [
             '_id' => $roleId,
             '_source' => $roleContent,
+            '_meta' => [],
             '_version' => 1
         ];
         $httpResponse = [
@@ -225,6 +228,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $saveResponse = [
             '_id' => $roleId,
             '_source' => $roleContent,
+            '_meta' => [],
             '_version' => 1
         ];
         $httpResponse = [
@@ -288,6 +292,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $saveResponse = [
             '_id' => $userId,
             '_source' => $userContent,
+            '_meta' => [],
             '_version' => 1
         ];
         $httpResponse = [
@@ -345,6 +350,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $saveResponse = [
             '_id' => $userId,
             '_source' => $userContent,
+            '_meta' => [],
             '_version' => 1
         ];
         $httpResponse = [
@@ -403,6 +409,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $replaceResponse = [
             '_id' => $userId,
             '_source' => $userContent,
+            '_meta' => [],
             '_version' => 1
         ];
         $httpResponse = [
@@ -522,7 +529,8 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
                     '_id' => 'test',
                     '_source' => [
                         'foo' => 'bar'
-                    ]
+                    ],
+                    '_meta' => []
                 ]
             ],
             'scrollId' => $scrollId,
@@ -534,7 +542,8 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
                     '_id' => 'test1',
                     '_source' => [
                         'foo' => 'bar'
-                    ]
+                    ],
+                    '_meta' => []
                 ]
             ],
             'total' => 2
@@ -676,7 +685,8 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
                     '_id' => 'test',
                     '_source' => [
                         'foo' => 'bar'
-                    ]
+                    ],
+                    '_meta' => []
                 ]
             ],
             'scrollId' => $scrollId,
@@ -688,7 +698,8 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
                     '_id' => 'test1',
                     '_source' => [
                         'foo' => 'bar'
-                    ]
+                    ],
+                    '_meta' => []
                 ]
             ],
             'total' => 2
@@ -820,7 +831,8 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         ];
         $getResponse = [
             '_id' => $profileId,
-            '_source' => $profileContent
+            '_source' => $profileContent,
+            '_meta' => []
         ];
         $httpResponse = [
             'error' => null,
@@ -882,7 +894,8 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         ];
         $getResponse = [
             '_id' => $roleId,
-            '_source' => $roleContent
+            '_source' => $roleContent,
+            '_meta' => []
         ];
         $httpResponse = [
             'error' => null,
@@ -937,7 +950,8 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         ];
         $getResponse = [
             '_id' => $userId,
-            '_source' => $userContent
+            '_source' => $userContent,
+            '_meta' => []
         ];
         $httpResponse = [
             'error' => null,
@@ -1100,7 +1114,8 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
                                 'allowInternalIndex'=> true
                             ]
                         ]
-                    ]
+                    ],
+                    '_meta' => []
                 ],
                 1 => [
                     '_id' => 'test1',
@@ -1113,7 +1128,8 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
                                 'allowInternalIndex'=> true
                             ]
                         ]
-                    ]
+                    ],
+                    '_meta' => []
                 ]
             ],
             'total' => 2
@@ -1192,7 +1208,8 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
                                 ]
                             ]
                         ]
-                    ]
+                    ],
+                    '_meta' => []
                 ],
                 1 => [
                     '_id' => 'test1',
@@ -1206,7 +1223,8 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
                                 ]
                             ]
                         ]
-                    ]
+                    ],
+                    '_meta' => []
                 ]
             ],
             'total' => 2
@@ -1278,14 +1296,16 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
                     '_source' => [
                         'foo' => 'bar',
                         'profile' => 'default'
-                    ]
+                    ],
+                    '_meta' => [],
                 ],
                 1 => [
                     '_id' => 'test1',
                     '_source' => [
                         'foo' => 'bar',
                         'profile' => 'default'
-                    ]
+                    ],
+                    '_meta' => [],
                 ]
             ],
             'total' => 2
@@ -1365,6 +1385,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $updateResponse = [
             '_id' => $profileId,
             '_source' => [ 'policies' => array_merge($policiesBase, $policies) ],
+            '_meta' => [],
             '_version' => 1
         ];
         $httpResponse = [
@@ -1432,6 +1453,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $updateResponse = [
             '_id' => $roleId,
             '_source' => array_merge($roleContent, $roleUpdateContent),
+            '_meta' => [],
             '_version' => 1
         ];
         $httpResponse = [
@@ -1463,7 +1485,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals(array_merge($roleContent, $roleUpdateContent), 'content', $result);
     }
 
-    function testUpdate()
+    function testUpdateUser()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;
         $requestId = uniqid();
@@ -1493,6 +1515,7 @@ class SecurityTest extends \PHPUnit_Framework_TestCase
         $updateResponse = [
             '_id' => $userId,
             '_source' => array_merge($userBaseContent, $userContent),
+            '_meta' => [],
             '_version' => 1
         ];
         $httpResponse = [

--- a/tests/Security/UserTest.php
+++ b/tests/Security/UserTest.php
@@ -86,6 +86,29 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($user->getProfileIds(), ['foo', 'bar', 'baz']);
     }
 
+    function testGetMeta()
+    {
+        $url = KuzzleTest::FAKE_KUZZLE_HOST;
+
+        $kuzzle = $this
+            ->getMockBuilder('\Kuzzle\Kuzzle')
+            ->setMethods(['emitRestRequest'])
+            ->setConstructorArgs([$url])
+            ->getMock();
+
+        $metas = [
+            'createdAt' => '0123456789',
+            'author' => '-1'
+        ];
+
+        $security = new Security($kuzzle);
+        $user = new User($security, 'foobar', [
+            'profileIds' => ['foo', 'bar', 'baz']
+        ], $metas);
+
+        $this->assertEquals($user->getMeta(), $metas);
+    }
+
     function testAddProfile()
     {
         $url = KuzzleTest::FAKE_KUZZLE_HOST;


### PR DESCRIPTION
# [3.0.1](https://github.com/kuzzleio/sdk-php/releases/tag/3.0.1) (2017-07-19)

### Compatibility

| Kuzzle | Proxy |
|--------|-------|
| 1.0.0 | 1.0.0 |

#### Bug fixes

- [ [#82](https://github.com/kuzzleio/sdk-php/pull/82) ]  Login: move "expiresIn" option from request.body to request root attribute   ([ballinette](https://github.com/ballinette))

#### Enhancements

- [ [#83](https://github.com/kuzzleio/sdk-php/pull/83) ] Added SDK version in volatile   ([samniisan](https://github.com/samniisan))
- [ [#81](https://github.com/kuzzleio/sdk-php/pull/81) ] Add meta to Security documents (User, Profile, Role)   ([samniisan](https://github.com/samniisan))
---

