### PR TITLE
Release 3.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,16 @@
 {
   "name": "kuzzleio/kuzzle-sdk",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "description": "Official PHP SDK for Kuzzle",
   "homepage": "http://kuzzle.io",
   "license": "Apache-2.0",
-  "authors": [{
-    "name": "The Kuzzle Team",
-    "email": "support@kuzzle.io",
-    "homepage": "http://kuzzle.io"
-  }],
+  "authors": [
+    {
+      "name": "The Kuzzle Team",
+      "email": "support@kuzzle.io",
+      "homepage": "http://kuzzle.io"
+    }
+  ],
   "support": {
     "issues": "https://github.com/kuzzleio/sdk-php/issues"
   },
@@ -17,12 +19,12 @@
       "Kuzzle\\": "src/"
     }
   },
-  "require" : {
+  "require": {
     "php": ">=5.4",
     "ramsey/uuid": "^3.4",
     "ext-curl": "*"
   },
-  "require-dev" : {
+  "require-dev": {
     "phpunit/phpunit": "4.8.*",
     "phpdocumentor/phpdocumentor": "2.9.0",
     "squizlabs/php_codesniffer": "2.*"

--- a/src/MemoryStorage.php
+++ b/src/MemoryStorage.php
@@ -185,7 +185,7 @@ class MemoryStorage
         'incrby' => ['required' => ['_id', 'value']],
         'incrbyfloat' => ['required' => ['_id', 'value']],
         'keys' => ['getter' => true, 'required' => [':pattern']],
-        'lindex' => ['getter' => true, 'required' => ['_id', ':index']],
+        'lindex' => ['getter' => true, 'required' => ['_id', ':idx']],
         'linsert' => ['required' => ['_id', 'position', 'pivot', 'value']],
         'llen' => ['getter' => true, 'required' => ['_id']],
         'lpop' => ['required' => ['_id']],

--- a/src/config/routes.json
+++ b/src/config/routes.json
@@ -422,7 +422,7 @@
     },
     "lindex": {
       "name": "lindex",
-      "route": "/ms/_lindex/:_id/:index",
+      "route": "/ms/_lindex/:_id/:idx",
       "method": "get"
     },
     "linsert": {
@@ -1009,7 +1009,7 @@
     },
     "lindex": {
       "name": "lindex",
-      "route": "/ms/_lindex/:_id/:index",
+      "route": "/ms/_lindex/:_id/:idx",
       "method": "get"
     },
     "linsert": {


### PR DESCRIPTION
# [3.0.2](https://github.com/kuzzleio/sdk-php/releases/tag/3.0.2) (2017-08-28)

### Compatibility

| Kuzzle | Proxy |
|--------|-------|
| 1.2.0 | 1.0.0 |

#### Others

- [ [#85](https://github.com/kuzzleio/sdk-php/pull/85) ] Rename index parameter into idx in memory storage  ([ballinette](https://github.com/ballinette))
---

