### PR TITLE
[4.x] collection.create should accept an optional mapping object

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright© 2016 Kaliop SAS
+   Copyright 2015-2018 Kuzzle
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
   "require": {
     "php": ">=5.4",
     "ramsey/uuid": "^3.4",
-    "ext-curl": "*",
-    "kuzzleio/kuzzle-sdk": "^3.0"
+    "ext-curl": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
   "require": {
     "php": ">=5.4",
     "ramsey/uuid": "^3.4",
-    "ext-curl": "*"
+    "ext-curl": "*",
+    "kuzzleio/kuzzle-sdk": "^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*",

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -155,16 +155,22 @@ class Collection
     }
 
     /**
-     * Create a new empty data collection, with no associated mapping.
+     * Create a new empty data collection. An optional mapping
+     * object can be provided
      *
+     * @param array $mapping Optional collection mapping description
      * @param array $options Optional parameters
      * @return boolean
      */
-    public function create(array $options = [])
+    public function create(array $mapping = [], array $options = [])
     {
+        $data = [
+            'body' => $mapping
+        ];
+
         $response = $this->kuzzle->query(
             $this->buildQueryArgs('collection', 'create'),
-            $this->kuzzle->addHeaders([], $this->headers),
+            $this->kuzzle->addHeaders($data, $this->headers),
             $options
         );
 

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -258,6 +258,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
         $requestId = uniqid();
         $index = 'index';
         $collection = 'collection';
+        $mapping = ['foo' => ['type' => 'keyword']];
 
         $httpRequest = [
             'route' => '/' . $index . '/' . $collection ,
@@ -268,7 +269,8 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
                 'action' => 'create',
                 'requestId' => $requestId,
                 'collection' => $collection,
-                'index' => $index
+                'index' => $index,
+                'body' => $mapping
             ],
             'query_parameters' => []
         ];
@@ -297,7 +299,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
          */
         $dataCollection = new Collection($kuzzle, $collection, $index);
 
-        $result = $dataCollection->create(['requestId' => $requestId]);
+        $result = $dataCollection->create(['foo' => ['type' => 'keyword']], ['requestId' => $requestId]);
 
         $this->assertEquals(true, $result);
     }


### PR DESCRIPTION
## What does this PR do ?

The PHP SDK v4.x version of https://github.com/kuzzleio/sdk-php/pull/94
