### PR TITLE
Fix document create

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  php:
+    image: kuzzleio/php-dev:7.3
+    command: php composer.phar install
+    network_mode: "host"
+    volumes:
+      - "..:/var/app"

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -2,6 +2,8 @@
 
 namespace Kuzzle;
 
+use Ramsey\Uuid\Uuid;
+
 use Kuzzle\Util\SearchResult;
 use InvalidArgumentException;
 
@@ -208,6 +210,8 @@ class Collection
 
         if (!empty($id)) {
             $data['_id'] = $id;
+        } else {
+            $data['_id'] = Uuid::uuid4()->toString();
         }
 
         $response = $this->kuzzle->query(

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -2,8 +2,6 @@
 
 namespace Kuzzle;
 
-use Ramsey\Uuid\Uuid;
-
 use Kuzzle\Util\SearchResult;
 use InvalidArgumentException;
 
@@ -210,10 +208,7 @@ class Collection
 
         if (!empty($id)) {
             $data['_id'] = $id;
-        } else {
-            $data['_id'] = Uuid::uuid4()->toString();
         }
-
         $response = $this->kuzzle->query(
             $this->buildQueryArgs('document', $action),
             $this->kuzzle->addHeaders($data, $this->headers),

--- a/src/Document.php
+++ b/src/Document.php
@@ -58,7 +58,7 @@ class Document
         }
 
         if (is_null($meta)) {
-          $meta = array();
+            $meta = array();
         }
 
         if (!empty($content)) {

--- a/src/Document.php
+++ b/src/Document.php
@@ -49,12 +49,16 @@ class Document
      * @param array $meta Initializes this document with the provided metadata
      * @return Document
      */
-    public function __construct(Collection $kuzzleDataCollection, $documentId = '', array $content = [], array $meta = [])
+    public function __construct(Collection $kuzzleDataCollection, $documentId = '', array $content = [], $meta = [])
     {
         $this->collection = $kuzzleDataCollection;
 
         if (!empty($documentId)) {
             $this->id = $documentId;
+        }
+
+        if (is_null($meta)) {
+          $meta = array();
         }
 
         if (!empty($content)) {

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -615,7 +615,6 @@ class Kuzzle
         if (!array_key_exists('requestId', $request)) {
             $request['requestId'] = Uuid::uuid4()->toString();
         }
-
          // @todo move this into RequestHandler
         return $this->emitRestRequest($this->convertRestRequest($request, $httpParams));
     }
@@ -1087,6 +1086,10 @@ class Kuzzle
             }
 
             $httpRequest['route'] = $this->routesDescription[$request['controller']][$request['action']]['route'];
+
+            if ($request['controller'] == 'document' && $request['action'] == 'create') {
+              $httpRequest['route'] = str_replace(':_id/', '', $httpRequest['route']);
+            }
         } else {
             $httpRequest['route'] = $request['route'];
             unset($request['route']);

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -1087,7 +1087,7 @@ class Kuzzle
 
             $httpRequest['route'] = $this->routesDescription[$request['controller']][$request['action']]['route'];
 
-            if ($request['controller'] == 'document' && $request['action'] == 'create') {
+            if ($request['controller'] == 'document' && $request['action'] == 'create' && !array_key_exists('_id', $request)) {
               $httpRequest['route'] = str_replace(':_id/', '', $httpRequest['route']);
             }
         } else {

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -1088,7 +1088,7 @@ class Kuzzle
             $httpRequest['route'] = $this->routesDescription[$request['controller']][$request['action']]['route'];
 
             if ($request['controller'] == 'document' && $request['action'] == 'create' && !array_key_exists('_id', $request)) {
-              $httpRequest['route'] = str_replace(':_id/', '', $httpRequest['route']);
+                $httpRequest['route'] = str_replace(':_id/', '', $httpRequest['route']);
             }
         } else {
             $httpRequest['route'] = $request['route'];

--- a/tests/DataCollectionTest.php
+++ b/tests/DataCollectionTest.php
@@ -431,7 +431,7 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
 
         $documentObject = new \Kuzzle\Document($dataCollection, $documentId, $documentContent, $documentMeta);
 
-        $document = $dataCollection->createDocument($documentObject, '', ['ifExist' => 'replace', 'requestId' => $requestId]);
+        $document = $dataCollection->createDocument($documentObject, $documentId, ['ifExist' => 'replace', 'requestId' => $requestId]);
 
         $this->assertInstanceOf('Kuzzle\Document', $document);
         $this->assertAttributeEquals($documentId, 'id', $document);


### PR DESCRIPTION
## What does this PR do ?

Autogenerate ID for when creating document without specifying ID.

Fix https://github.com/kuzzleio/sdk-php/issues/102

### How should this be manually tested?

  - Step 1 : Create index `myindex` and collection `mycollection`
  - Step 2 : Run this script twice:
```
<?php
include __DIR__ . '/tests/bootstrap.php';

$kuzzle = new \Kuzzle\Kuzzle('localhost');

$collection = 'mycollection';
$index = 'myindex';

// enabling auto refresh (avoiding sleep between add/deletion and search)
$kuzzle->setAutoRefresh($index);

$collection = $kuzzle->collection($collection, $index);


// add a document
print_r('add a document');
print_r("\n");
$document = $collection->createDocument(['foo' => 'bar']);
print_r($document->serialize());
```
### Other changes

 - Add a docker-compose file for development (See this PR for custom image https://github.com/kuzzleio/kuzzle-containers/pull/47)
