### PR TITLE
Fix createFirstAdmin endpoint

### DIFF
--- a/src/config/routes.json
+++ b/src/config/routes.json
@@ -1658,7 +1658,7 @@
     },
     "createFirstAdmin": {
       "name": "createFirstAdmin",
-      "route": "/_createFirstAdmin",
+      "route": "/:_id/_createFirstAdmin",
       "method": "post"
     },
     "mDeleteProfiles": {


### PR DESCRIPTION
## What does this PR do ?
This PR allow developers to provide a KUID when generating a new admin using query method in the PHP SDK

### How should this be manually tested?
  - Step 1 : create a kuzzle->query
```
$data = [];

        $data['body'] = [
            'content' => [
                'name' => 'kuzzle_admin'
            ],
            'credentials' => [
                'local' => [
                    'username' => $this->kuzzleAdminUsername,
                    'password' => $this->kuzzleAdminPassword
                ]
            ]
        ];
        $data['_id'] = 'kuzzle_admin';

$kuzzleInstance->query(
            $kuzzleInstance->buildQueryArgs('security', 'createFirstAdmin'),
            $kuzzleInstance->addHeaders($data, $kuzzleInstance->getHeaders())
        );

```

  - Step 2 : Constat that the new admin is created with the specified id
  ...

