### PR TITLE
[ci] Remove PHP nightly Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - '5.6'
   - '7.0'
   - hhvm
-  - nightly
 before_script: composer install
 script:
   - php ./vendor/bin/phpcs -p -n --standard=PSR2 src

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - '5.5'
   - '5.6'
   - '7.0'
-  - hhvm
 before_script: composer install
 script:
   - php ./vendor/bin/phpcs -p -n --standard=PSR2 src


### PR DESCRIPTION
Since PHP nightly goes from version 7.x to version 8, `nightly` PHP job is broken.
We do not have time to make our SDK compatible with PHP nightly version
so let's remove this job in Travis CI to move forward.
