### PR TITLE
Add missing options feature to Kuzzle constructor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzleio/kuzzle-sdk",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Official PHP SDK for Kuzzle",
   "homepage": "http://kuzzle.io",
   "license": "Apache-2.0",

--- a/src/Kuzzle.php
+++ b/src/Kuzzle.php
@@ -83,6 +83,11 @@ class Kuzzle
      */
     protected $sdkVersion;
 
+    /**
+     * @var boolean
+     */
+    private $sslConnection;
+
 
     /**
      * Kuzzle constructor.
@@ -113,7 +118,22 @@ class Kuzzle
             $this->port = $options['port'];
         }
 
-        $this->url = 'http://' . $host . ':' . $this->port;
+        if (array_key_exists('headers', $options)) {
+            $this->headers = $options['headers'];
+        }
+
+        if (array_key_exists('volatile', $options)) {
+            $this->volatile = $options['volatile'];
+        }
+
+        if (array_key_exists('sslConnection', $options)) {
+            $this->sslConnection = $options['sslConnection'];
+        } else {
+            $this->sslConnection = false;
+        }
+
+        $proto = $this->sslConnection ? 'https' : 'http';
+        $this->url = $proto . '://' . $host . ':' . $this->port;
         $this->loadRoutesDescription($this->routesDescriptionFile);
 
         $this->sdkVersion = json_decode(file_get_contents(__DIR__.'/../composer.json'))->version;
@@ -292,6 +312,14 @@ class Kuzzle
     public function getVolatile()
     {
         return $this->volatile;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isSSL()
+    {
+        return $this->sslConnection;
     }
 
     /**

--- a/tests/KuzzleTest.php
+++ b/tests/KuzzleTest.php
@@ -13,13 +13,21 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
         $host = self::FAKE_KUZZLE_HOST;
 
         try {
-            $kuzzle = new \Kuzzle\Kuzzle($host, ['port' => 1234]);
+            $headers = [ 'Content-Type' => 'application/json' ];
+            $volatile = [ 'job' => 'PHP CEO' ];
+            $options = [
+              'port' => 1234,
+              'headers' => $headers,
+              'volatile' => $volatile,
+              'sslConnection' => true
+            ];
+            $kuzzle = new \Kuzzle\Kuzzle($host, $options);
 
             // Assert type
             $this->assertInstanceOf('\Kuzzle\Kuzzle', $kuzzle);
 
             // Assert Url
-            $this->assertAttributeEquals('http://' . $host . ':1234', 'url', $kuzzle);
+            $this->assertAttributeEquals('https://' . $host . ':1234', 'url', $kuzzle);
 
             // Assert if one (random) route is loaded
             $routesDescription = $this->readAttribute($kuzzle, 'routesDescription');
@@ -29,6 +37,9 @@ class KuzzleTest extends \PHPUnit_Framework_TestCase
                 'route' =>  '/_now'
             ];
 
+            $this->assertEquals($headers, $kuzzle->getHeaders());
+            $this->assertEquals($volatile, $kuzzle->getVolatile());
+            $this->assertEquals(true, $kuzzle->isSSL());
             $this->assertEquals($routesNow, $routesDescription['server']['now']);
         }
         catch (Exception $e) {


### PR DESCRIPTION
## What does this PR do ?
As it's described [here](https://docs.kuzzle.io/sdk/php/3/core-classes/kuzzle/constructor#options)
users should be able to specify to the Kuzzle constructor:
* the default HTTP headers
* the volatile
* SSL connection